### PR TITLE
update profiles class

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -42,9 +42,9 @@ def cog_translate(src, dst, dst_opts,
 
             indexes = indexes if indexes else src.indexes
             meta = src.meta
+            meta['count'] = len(indexes)
             meta.pop('nodata', None)
             meta.pop('alpha', None)
-            meta['count'] = len(indexes)
             meta.pop('compress', None)
             meta.update(**dst_opts)
 

--- a/rio_cogeo/profiles.py
+++ b/rio_cogeo/profiles.py
@@ -1,58 +1,80 @@
 """rio_cogeo.profiles: CloudOptimized profiles."""
 
+from rasterio.profiles import Profile
+from rasterio.dtypes import uint8
 
-class COG(dict):
+
+class YCbCrProfile(Profile):
+    """Tiled, pixel-interleaved, JPEG-compressed, YCbCr colorspace, 8-bit GTiff."""
+
+    defaults = {
+        'driver': 'GTiff',
+        'interleave': 'pixel',
+        'tiled': True,
+        'blockxsize': 512,
+        'blockysize': 512,
+        'compress': 'JPEG',
+        'photometric': 'YCbCr',
+        'dtype': uint8}
+
+
+class LZWProfile(Profile):
+    """Tiled, pixel-interleaved, LZW-compressed GTiff."""
+
+    defaults = {
+        'driver': 'GTiff',
+        'interleave': 'pixel',
+        'tiled': True,
+        'blockxsize': 512,
+        'blockysize': 512,
+        'compress': 'LZW'}
+
+
+class DEFLATEProfile(Profile):
+    """Tiled, pixel-interleaved, DEFLATE-compressed GTiff."""
+
+    defaults = {
+        'driver': 'GTiff',
+        'interleave': 'pixel',
+        'tiled': True,
+        'blockxsize': 512,
+        'blockysize': 512,
+        'compress': 'DEFLATE'}
+
+
+class PACKBITSProfile(Profile):
+    """Tiled, pixel-interleaved, PACKBITS-compressed GTiff."""
+
+    defaults = {
+        'driver': 'GTiff',
+        'interleave': 'pixel',
+        'tiled': True,
+        'blockxsize': 512,
+        'blockysize': 512,
+        'compress': 'PACKBITS'}
+
+
+class RAWProfile(Profile):
+    """Tiled, pixel-interleaved, no-compressed GTiff."""
+
+    defaults = {
+        'driver': 'GTiff',
+        'interleave': 'pixel',
+        'tiled': True,
+        'blockxsize': 512,
+        'blockysize': 512}
+
+
+class COGProfiles(dict):
     """CloudOptimized GeoTIFF profiles."""
 
     def __init__(self):
-        """Tiled, pixel-interleaved, JPEG-compressed GTiff."""
-        self.update({'ycbcr': {
-            'driver': 'GTiff',
-            'interleave': 'pixel',
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'compress': 'JPEG',
-            'photometric': 'YCbCr'}})
-
-        """Tiled, pixel-interleaved, LZW-compressed GTiff."""
-        self.update({'lzw': {
-            'driver': 'GTiff',
-            'interleave': 'pixel',
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'compress': 'LZW',
-            'photometric': 'RGB'}})
-
-        """Tiled, pixel-interleaved, DEFLATE-compressed GTiff."""
-        self.update({'deflate': {
-            'driver': 'GTiff',
-            'interleave': 'pixel',
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'compress': 'DEFLATE',
-            'photometric': 'RGB'}})
-
-        """Tiled, pixel-interleaved, PACKBITS-compressed GTiff."""
-        self.update({'packbits': {
-            'driver': 'GTiff',
-            'interleave': 'pixel',
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'compress': 'PACKBITS',
-            'photometric': 'RGB'}})
-
-        """Tiled, pixel-interleaved, no-compression GTiff."""
-        self.update({'raw': {
-            'driver': 'GTiff',
-            'interleave': 'pixel',
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'photometric': 'RGB'}})
+        """Initialize COGProfiles dict."""
+        self.update({'ycbcr': YCbCrProfile()})
+        self.update({'lzw': LZWProfile()})
+        self.update({'deflate': DEFLATEProfile()})
+        self.update({'packbits': PACKBITSProfile()})
+        self.update({'raw': RAWProfile()})
 
     def get(self, key):
         """Like normal item access but error."""
@@ -61,4 +83,4 @@ class COG(dict):
         return self[key].copy()
 
 
-cog_profiles = COG()
+cog_profiles = COGProfiles()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,8 +26,8 @@ def test_cogeo_valid():
             assert src.meta['dtype'] == 'uint8'
             assert not src.is_tiled  # Because blocksize is 512 and the file is 512, the output is not tiled
             assert src.compression.name == 'jpeg'
-            assert src.profile['blockxsize'] == '512'
-            assert src.profile['blockysize'] == '512'
+            assert not src.profile.get('blockxsize')
+            assert not src.profile.get('blockysize')
             assert src.profile['photometric'] == 'ycbcr'
             assert src.profile['interleave'] == 'pixel'
             assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
@@ -100,6 +100,5 @@ def test_cogeo_validGdalOptions():
         assert result.exit_code == 0
         with rasterio.open('output.tif') as src:
             assert src.compression.name == 'deflate'
-            assert src.profile['blockxsize'] == '512'
-            assert src.profile['blockysize'] == '512'
-            assert src.profile['photometric'] == 'rgb'
+            assert not src.profile.get('blockxsize')
+            assert not src.profile.get('blockysize')

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -24,8 +24,8 @@ def test_cog_translate_valid():
             assert src.meta['dtype'] == 'uint8'
             assert not src.is_tiled  # Because blocksize is 512 and the file is 512, the output is not tiled
             assert src.compression.name == 'jpeg'
-            assert src.profile['blockxsize'] == '512'
-            assert src.profile['blockysize'] == '512'
+            assert not src.profile.get('blockxsize')
+            assert not src.profile.get('blockysize')
             assert src.profile['photometric'] == 'ycbcr'
             assert src.profile['interleave'] == 'pixel'
             assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
@@ -43,9 +43,8 @@ def test_cog_translate_validRaw():
             assert src.meta['dtype'] == 'uint8'
             assert not src.is_tiled  # Because blocksize is 512 and the file is 512, the output is not tiled
             assert not src.compression
-            assert src.profile['blockxsize'] == '512'
-            assert src.profile['blockysize'] == '512'
-            assert src.profile['photometric'] == 'rgb'
+            assert not src.profile.get('blockxsize')
+            assert not src.profile.get('blockysize')
             assert src.profile['interleave'] == 'pixel'
             assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -23,7 +23,6 @@ def test_profiles_lzw():
     assert profile['compress'] == 'LZW'
     assert profile['blockxsize'] == 512
     assert profile['blockysize'] == 512
-    assert profile['photometric'] == 'RGB'
     assert profile['interleave'] == 'pixel'
 
 
@@ -34,7 +33,6 @@ def test_profiles_deflate():
     assert profile['compress'] == 'DEFLATE'
     assert profile['blockxsize'] == 512
     assert profile['blockysize'] == 512
-    assert profile['photometric'] == 'RGB'
     assert profile['interleave'] == 'pixel'
 
 
@@ -45,7 +43,6 @@ def test_profiles_packbits():
     assert profile['compress'] == 'PACKBITS'
     assert profile['blockxsize'] == 512
     assert profile['blockysize'] == 512
-    assert profile['photometric'] == 'RGB'
     assert profile['interleave'] == 'pixel'
 
 
@@ -56,7 +53,6 @@ def test_profiles_raw():
     assert not profile.get('compress')
     assert profile['blockxsize'] == 512
     assert profile['blockysize'] == 512
-    assert profile['photometric'] == 'RGB'
     assert profile['interleave'] == 'pixel'
 
 


### PR DESCRIPTION
This PR does: 
- refactor `rio_cogeo.profiles` 
- each profile is now a proper `rasterio.profiles.Profile`
- update tests
- remove default `RGB` photometric

👋 @sgillies I tried to translate https://github.com/mapbox/rio-cogeo/pull/1#discussion_r177473729

I choose to keep the main class as a `dict` mostly because of https://docs.python.org/2/faq/design.html#why-isn-t-there-a-switch-or-case-statement-in-python
