### PR TITLE
[WIP] Make mask creation optional

### DIFF
--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -94,9 +94,14 @@ def cogeo(
 
     config = dict(
         NUM_THREADS=threads,
-        GDAL_TIFF_INTERNAL_MASK=os.environ.get("GDAL_TIFF_INTERNAL_MASK", True),
         GDAL_TIFF_OVR_BLOCKSIZE=os.environ.get("GDAL_TIFF_OVR_BLOCKSIZE", block_size),
     )
+    if addmask:
+        config.update(
+            dict(
+                GDAL_TIFF_INTERNAL_MASK=os.environ.get("GDAL_TIFF_INTERNAL_MASK", True)
+            )
+        )
 
     cog_translate(
         input,

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -53,6 +53,9 @@ class CustomType:
     "--alpha", type=int, help="Force mask creation from a given alpha band number"
 )
 @click.option(
+    "--addmask", type=bool, default=True, help="Add internal/external bitmask"
+)
+@click.option(
     "--overview-level", type=int, default=6, help="Overview level (default: 6)"
 )
 @click.option(
@@ -72,6 +75,7 @@ def cogeo(
     cogeo_profile,
     nodata,
     alpha,
+    addmask,
     overview_level,
     overview_resampling,
     threads,
@@ -101,6 +105,7 @@ def cogeo(
         bidx,
         nodata,
         alpha,
+        addmask,
         overview_level,
         overview_resampling,
         config,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def _has_mask(src):
 
 
 def _has_alpha(src):
-    """Check for mask in source."""
+    """Check for alpha band in source."""
     if any([MaskFlags.alpha in flags for flags in src.mask_flag_enums]):
         return True
     return False


### PR DESCRIPTION
resolves #32 
This PR makes mask creation optional when creation a COG. 

## To Do
If this is approved, we need to update the documentation to explain how nodata/alpha are handled in both case (with/without mask). e.g we don't remove the nodata/alpha tag in the profile, which will be then copied in the output profile. I already see a `bug` when we pass a `nodata` or `alpha` values via options which will not be copied in the profile. (I'll comment the code) 

cc @perrygeo @sgillies  