### PR TITLE
overview blocksize option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Next (TBD)
 ----------
 - add more logging and `--quiet` option (#46)
+- add `--overview-blocksize` to set overview's internal tile size (#60)
 
 Bug fixes:
 
@@ -11,6 +12,7 @@ Breacking Changes:
 
 - internal mask creation is now optional (--add-mask).
 - internal nodata or alpha channel can be forwarded to the output dataset.
+- removed default overview blocksize to be equal to the raw data blocksize (#60)
 
 1.0dev10 (2019-02-12)
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Usage
     --overview-level INTEGER        Overview level (if not provided, appropriate overview level will be selected until the
                                     smallest overview is smaller than the internal block size).
     --overview-resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss] Resampling algorithm.
+    --overview-blocksize TEXT       Overview's internal tile size (default defined by GDAL_TIFF_OVR_BLOCKSIZE env or 128)
     --threads INTEGER
     --co, --profile NAME=VALUE      Driver specific creation options.See the documentation for the selected output driver for more information.
     -q, --quiet                     Suppress progress bar and other non-error output.
@@ -67,6 +68,11 @@ Examples
 
   # Create a COGEO without compression and with 1024x1024 block size
   $ rio cogeo mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw
+
+  # Create a COGEO without compression and with 1024x1024 block size and 256 overview blocksize
+  $ rio cogeo mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw --overview-blocksize 256
+  $ GDAL_TIFF_OVR_BLOCKSIZE=256 rio cogeo mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw
+
 
 Default COGEO profiles
 ======================
@@ -127,7 +133,7 @@ Default profiles are tiled with 512x512 blocksizes.
 Overview levels
 ===============
 
-By default rio cogeo will calculate the optimal overview level based on dataset size and internal tile size 
+By default rio cogeo will calculate the optimal overview level based on dataset size and internal tile size
 (overview should not be smaller than internal tile size (e.g 512px). Overview level will be translated to decimation level of power of two.
 
 Internal tile size
@@ -135,23 +141,23 @@ Internal tile size
 
 By default rio cogeo will create a dataset with 512x512 internal tile size. This can be updated by passing `--co BLOCKXSIZE=64 --co BLOCKYSIZE=64` options.
 
-**Web tiling optimization** 
+**Web tiling optimization**
 
-if the input dataset is aligned to web mercator grid, the internal tile size should be equal to the web map tile size (256 or 512px) 
-output dataset is compressed, 
+if the input dataset is aligned to web mercator grid, the internal tile size should be equal to the web map tile size (256 or 512px)
+output dataset is compressed,
 
-if the input dataset is not aligned to web mercator grid, the tiler will need to fetch multiple internal tiles. 
-Because GDAL can merge range request, using small internal tiles (e.g 128) will reduce the number of byte transfered and minimized the useless bytes transfered. 
+if the input dataset is not aligned to web mercator grid, the tiler will need to fetch multiple internal tiles.
+Because GDAL can merge range request, using small internal tiles (e.g 128) will reduce the number of byte transfered and minimized the useless bytes transfered.
 
 Nodata, Alpha and Mask
 ======================
 
-By default rio-cogeo will forward any nodata value or alpha channel to the output COG. 
+By default rio-cogeo will forward any nodata value or alpha channel to the output COG.
 
 If your dataset type is **Byte** or **Unit16**, you could use internal bit mask (with the `--add-mask` option)
 to replace the Nodata value or Alpha band in output dataset (supported by most GDAL based backends).
 
-Note: when adding a `mask` with an input dataset having an alpha band you'll 
+Note: when adding a `mask` with an input dataset having an alpha band you'll
 need to use the `bidx` options to remove it from the output dataset.
 
 .. code-block:: console
@@ -159,9 +165,9 @@ need to use the `bidx` options to remove it from the output dataset.
   # Replace the alpha band by an internal mask
   $ rio cogeo mydataset_withalpha.tif mydataset_withmask.tif --cog-profile raw --add-mask --bidx 1,2,3
 
-**Important** 
+**Important**
 
-Using internal nodata value with lossy compression (`webp`, `jpeg`) is not recommanded. 
+Using internal nodata value with lossy compression (`webp`, `jpeg`) is not recommanded.
 Please use internal masking (or alpha band if using webp)
 
 

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -85,6 +85,11 @@ class NodataParamType(click.ParamType):
     ),
     default="nearest",
 )
+@click.option(
+    "--overview-blocksize",
+    default=lambda: os.environ.get("GDAL_TIFF_OVR_BLOCKSIZE", 128),
+    help="Overview's internal tile size (default defined by GDAL_TIFF_OVR_BLOCKSIZE env or 128)",
+)
 @click.option("--threads", type=int, default=8)
 @options.creation_options
 @click.option(
@@ -102,6 +107,7 @@ def cogeo(
     add_mask,
     overview_level,
     overview_resampling,
+    overview_blocksize,
     threads,
     creation_options,
     quiet,
@@ -112,14 +118,10 @@ def cogeo(
     if creation_options:
         output_profile.update(creation_options)
 
-    block_size = min(
-        int(output_profile["blockxsize"]), int(output_profile["blockysize"])
-    )
-
     config = dict(
         NUM_THREADS=threads,
         GDAL_TIFF_INTERNAL_MASK=os.environ.get("GDAL_TIFF_INTERNAL_MASK", True),
-        GDAL_TIFF_OVR_BLOCKSIZE=os.environ.get("GDAL_TIFF_OVR_BLOCKSIZE", block_size),
+        GDAL_TIFF_OVR_BLOCKSIZE=str(overview_blocksize),
     )
 
     cog_translate(


### PR DESCRIPTION
close #60 

This PR adds:
- `--overview-blocksize` CLI's option to define the internal overview's tile size. 

⚠️ **breacking change**⚠️ 
Overview's internal tile size is no more equal to the raw data block size but will be by default define by `GDAL_TIFF_OVR_BLOCKSIZE` env or be 128.

