### PR TITLE
copy terracotta method for custom TemporaryFile

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import warnings
-import tempfile
 from contextlib import contextmanager
 
 import click
@@ -27,16 +26,15 @@ IN_MEMORY_THRESHOLD = int(os.environ.get("IN_MEMORY_THRESHOLD", 10980 * 10980))
 
 
 @contextmanager
-def _named_tempfile(dir):
-    fileobj = tempfile.NamedTemporaryFile(dir=dir, suffix=".tif")
+def TemporaryRasterFile(fname, suffix=".tmp"):
+    """Create temporary file."""
+    tmp_name = fname + suffix
+    fileobj = open(tmp_name, "wb")
     fileobj.close()
     try:
         yield fileobj.name
     finally:
         os.remove(fileobj.name)
-
-
-TemporaryRasterFile = _named_tempfile
 
 
 def cog_translate(
@@ -138,8 +136,7 @@ def cog_translate(
                         tmpfile = ctx.enter_context(MemoryFile())
                         tmp_dst = ctx.enter_context(tmpfile.open(**meta))
                     else:
-                        outdir = os.path.dirname(dst_path)
-                        tmpfile = ctx.enter_context(TemporaryRasterFile(outdir))
+                        tmpfile = ctx.enter_context(TemporaryRasterFile(dst_path))
                         tmp_dst = ctx.enter_context(rasterio.open(tmpfile, "w", **meta))
 
                     wind = list(tmp_dst.block_windows(1))

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import tempfile
 import warnings
 from contextlib import contextmanager
 
@@ -26,10 +27,11 @@ IN_MEMORY_THRESHOLD = int(os.environ.get("IN_MEMORY_THRESHOLD", 10980 * 10980))
 
 
 @contextmanager
-def TemporaryRasterFile(fname, suffix=".tmp"):
+def TemporaryRasterFile(dst_path, suffix=".tif"):
     """Create temporary file."""
-    tmp_name = fname + suffix
-    fileobj = open(tmp_name, "wb")
+    dir = os.path.dirname(dst_path)
+    # Make sure we can write file
+    fileobj = tempfile.NamedTemporaryFile(dir=dir, suffix=suffix, delete=False)
     fileobj.close()
     try:
         yield fileobj.name

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -27,8 +27,8 @@ IN_MEMORY_THRESHOLD = int(os.environ.get("IN_MEMORY_THRESHOLD", 10980 * 10980))
 
 
 @contextmanager
-def _named_tempfile():
-    fileobj = tempfile.NamedTemporaryFile(suffix=".tif")
+def _named_tempfile(dir):
+    fileobj = tempfile.NamedTemporaryFile(dir=dir, suffix=".tif")
     fileobj.close()
     try:
         yield fileobj.name
@@ -138,7 +138,8 @@ def cog_translate(
                         tmpfile = ctx.enter_context(MemoryFile())
                         tmp_dst = ctx.enter_context(tmpfile.open(**meta))
                     else:
-                        tmpfile = ctx.enter_context(TemporaryRasterFile())
+                        outdir = os.path.dirname(dst_path)
+                        tmpfile = ctx.enter_context(TemporaryRasterFile(outdir))
                         tmp_dst = ctx.enter_context(rasterio.open(tmpfile, "w", **meta))
 
                     wind = list(tmp_dst.block_windows(1))


### PR DESCRIPTION
This has a better memory footprint and doesn't show the memory surge as seen with direct `tempfile.NamedTemporaryFile` as explained https://github.com/cogeotiff/rio-cogeo/pull/75#issuecomment-482745580

Rasterio/GDAL is doing something strange with `/vsimem` when closing them, leading to a huge memory usage.