### PR TITLE
New profiles + THREADS fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+1.1.3 (2019-09-16)
+------------------
+
+- Add lzma/lerc/lerc_deflate/lerc_zstd profiles (#97)
+- Add warnings and notes for `non-standard` compression (#97)
+- fix THREADS definition for GDAL config 
+
 1.1.2 (2019-09-12)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ $ rio cogeo create --help
 
   Options:
     -b, --bidx BIDX                 Band indexes to copy.
-    -p, --cog-profile [jpeg|webp|zstd|lzw|deflate|packbits|raw] CloudOptimized GeoTIFF profile (default: deflate).
+    -p, --cog-profile [jpeg|webp|zstd|lzw|deflate|packbits|lzma|lerc|lerc_deflate|lerc_zstd|raw] 
+                                    CloudOptimized GeoTIFF profile (default: deflate).
     --nodata NUMBER|nan             Set nodata masking values for input dataset.
     --add-mask                      Force output dataset creation with an internal mask (convert alpha band or nodata to mask).
     -t, --dtype [ubyte|uint8|uint16|int16|uint32|int32|float32|float64]
@@ -77,7 +78,7 @@ $ rio cogeo create --help
                                     or ensure MAX_ZOOM equality for multiple dataset accross latitudes.
     -r, --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss] Resampling algorithm.
     --in-memory / --no-in-memory    Force processing raster in memory / not in memory (default: process in memory if smaller than 120 million pixels)
-    --threads INTEGER
+    --threads THREADS               Number of worker threads for multi-threaded compression (default: ALL_CPUS)
     --co, --profile NAME=VALUE      Driver specific creation options.See the documentation for the selected output driver for more information.
     -q, --quiet                     Remove progressbar and other non-error output.
     --help                          Show this message and exit.
@@ -110,6 +111,8 @@ $ rio cogeo create mydataset.tif mydataset_jpeg.tif -b 1,2,3 --add-mask --cog-pr
 
 ## Default COGEO profiles
 
+Default profiles are tiled with 512x512 blocksizes.
+
 **JPEG**
 
 - JPEG compression
@@ -122,12 +125,14 @@ $ rio cogeo create mydataset.tif mydataset_jpeg.tif -b 1,2,3 --add-mask --cog-pr
 - WEBP compression
 - PIXEL interleave
 - limited to uint8 datatype and 3 or 4 bands data
+- Non-Standard, might not be supported by software not build against GDAL+internal libtiff + libwebp
 - Available for GDAL>=2.4.0
 
 **ZSTD**
 
 - ZSTD compression
 - PIXEL interleave
+- Non-Standard, might not be supported by software not build against GDAL + internal libtiff + libzstd
 - Available for GDAL>=2.3.0
 
 *Note* in Nov 2018, there was a change in libtiff's ZSTD tags which create incompatibility for old ZSTD compressed GeoTIFF [(link)](https://lists.osgeo.org/pipermail/gdal-dev/2018-November/049289.html)
@@ -147,20 +152,49 @@ $ rio cogeo create mydataset.tif mydataset_jpeg.tif -b 1,2,3 --add-mask --cog-pr
 - PACKBITS compression
 - PIXEL interleave
 
+**LZMA**
+
+- LZMA compression
+- PIXEL interleave
+
+**LERC**
+
+- LERC compression
+- PIXEL interleave
+- Default MAX_Z_ERROR=0 (lossless)
+- Non-Standard, might not be supported by software not build against GDAL + internal libtiff
+- Available for GDAL>=2.4.0
+
+**LERC_DEFLATE**
+
+- LERC_DEFLATE compression
+- PIXEL interleave
+- Default MAX_Z_ERROR=0 (lossless)
+- Non-Standard, might not be supported by software not build against GDAL + internal libtiff + libzstd
+- Available for GDAL>=2.4.0
+
+**LERC_ZSTD**
+
+- LERC_ZSTD compression
+- PIXEL interleave
+- Default MAX_Z_ERROR=0 (lossless)
+- Non-Standard, might not be supported by software not build against GDAL + internal libtiff + libzstd
+- Available for GDAL>=2.4.0
+
 **RAW**
 
 - NO compression
 - PIXEL interleave
 
-Default profiles are tiled with 512x512 blocksizes.
-
-Profiles can be extended by providing '--co' option in command line
+**Profiles can be extended by providing '--co' option in command line**
 
 
 ```bash
 # Create a COGEO without compression and with 1024x1024 block size and 256 overview blocksize
 $ rio cogeo create mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw --overview-blocksize 256
 ```
+
+See https://gdal.org/drivers/raster/gtiff.html#creation-options for full details of creation options.
 
 ## Web-Optimized COG
 

--- a/rio_cogeo/profiles.py
+++ b/rio_cogeo/profiles.py
@@ -1,5 +1,7 @@
 """rio_cogeo.profiles: CloudOptimized profiles."""
 
+import warnings
+
 from rasterio.profiles import Profile
 
 
@@ -85,6 +87,58 @@ class PACKBITSProfile(Profile):
     }
 
 
+class LZMAProfile(Profile):
+    """Tiled, pixel-interleaved, LZMA-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LZMA",
+    }
+
+
+class LERCProfile(Profile):
+    """Tiled, pixel-interleaved, LERC-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC",
+    }
+
+
+class LERCDEFLATEProfile(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+    }
+
+
+class LERCZSTDProfile(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+    }
+
+
 class RAWProfile(Profile):
     """Tiled, pixel-interleaved, no-compressed GTiff."""
 
@@ -110,6 +164,10 @@ class COGProfiles(dict):
                 "lzw": LZWProfile(),
                 "deflate": DEFLATEProfile(),
                 "packbits": PACKBITSProfile(),
+                "lzma": LZMAProfile(),
+                "lerc": LERCProfile(),
+                "lerc_deflate": LERCDEFLATEProfile(),
+                "lerc_zstd": LERCZSTDProfile(),
                 "raw": RAWProfile(),
             }
         )
@@ -118,6 +176,12 @@ class COGProfiles(dict):
         """Like normal item access but error."""
         if key not in (self.keys()):
             raise KeyError("{} is not a valid COG profile name".format(key))
+
+        if key in ["zstd", "webp", "lerc", "lerc_deflate", "lerc_zstd"]:
+            warnings.warn(
+                "Non-standard compression schema: {}. The output COG might not be fully"
+                " supported by software not build against latest libtiff.".format(key)
+            )
 
         return self[key].copy()
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info >= (3, 6):
 
 setup(
     name="rio-cogeo",
-    version="1.1.2",
+    version="1.1.3",
     description=u"CloudOptimized GeoTIFF (COGEO) creation plugin for rasterio",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -55,6 +55,46 @@ def test_profiles_packbits():
     assert profile["interleave"] == "pixel"
 
 
+def test_profiles_lzma():
+    """Should work as expected (return lzma profile)."""
+    profile = cog_profiles.get("lzma")
+    assert profile["tiled"]
+    assert profile["compress"] == "LZMA"
+    assert profile["blockxsize"] == 512
+    assert profile["blockysize"] == 512
+    assert profile["interleave"] == "pixel"
+
+
+def test_profiles_lerc():
+    """Should work as expected (return lerc profile)."""
+    profile = cog_profiles.get("lerc")
+    assert profile["tiled"]
+    assert profile["compress"] == "LERC"
+    assert profile["blockxsize"] == 512
+    assert profile["blockysize"] == 512
+    assert profile["interleave"] == "pixel"
+
+
+def test_profiles_lerc_deflate():
+    """Should work as expected (return lerc_deflate profile)."""
+    profile = cog_profiles.get("lerc_deflate")
+    assert profile["tiled"]
+    assert profile["compress"] == "LERC_DEFLATE"
+    assert profile["blockxsize"] == 512
+    assert profile["blockysize"] == 512
+    assert profile["interleave"] == "pixel"
+
+
+def test_profiles_lerc_zstd():
+    """Should work as expected (return lerc_deflate profile)."""
+    profile = cog_profiles.get("lerc_zstd")
+    assert profile["tiled"]
+    assert profile["compress"] == "LERC_ZSTD"
+    assert profile["blockxsize"] == 512
+    assert profile["blockysize"] == 512
+    assert profile["interleave"] == "pixel"
+
+
 def test_profiles_raw():
     """Should work as expected (return packbits profile)."""
     profile = cog_profiles.get("raw")
@@ -63,6 +103,12 @@ def test_profiles_raw():
     assert profile["blockxsize"] == 512
     assert profile["blockysize"] == 512
     assert profile["interleave"] == "pixel"
+
+
+def test_profiles_nonstandard():
+    """Should work as expected (warns on non-standard compression)."""
+    with pytest.warns(UserWarning):
+        cog_profiles.get("zstd")
 
 
 def test_profiles_copy():


### PR DESCRIPTION
closes #97 

This PR adds new profiles: lzma, lerc, lerc_deflate, lerc_zstd and additional notes/warnings about non-standard compression schemes.

The PR also fix a bug in the gdal config definition where we use `NUM_THREADS` instead of `GDAL_NUM_THREADS` for writing options. 

```
$ time rio cogeo create iw-vh.tiff iw-vh_cog.tif --threads 1
rio cogeo create iw-vh.tiff iw-vh_cog.tif --threads 1  110.00s user 9.55s system 91% cpu 2:10.19 total

$ time rio cogeo create iw-vh.tiff iw-vh_cog.tif            
rio cogeo create iw-vh.tiff iw-vh_cog.tif  141.70s user 9.58s system 174% cpu 1:26.57 total
```