### PR TITLE
Strict option for cogeo validation

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -437,7 +437,7 @@ def cog_validate(src_path, strict=False):
             click.echo("- " + e, err=True)
 
         return False
-    
+
     if warnings and strict:
         return False
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -280,7 +280,7 @@ def cog_translate(
                 copy(tmp_dst, dst_path, copy_src_overviews=True, **dst_kwargs)
 
 
-def cog_validate(src_path):
+def cog_validate(src_path, strict=False):
     """
     Validate Cloud Optimized Geotiff.
 
@@ -288,6 +288,8 @@ def cog_validate(src_path):
     ----------
     src_path : str or PathLike object
         A dataset path or URL. Will be opened in "r" mode.
+    strict: bool
+        Treat warnings as errors
 
     This script is the rasterio equivalent of
     https://svn.osgeo.org/gdal/trunk/gdal/swig/python/samples/validate_cloud_optimized_geotiff.py
@@ -434,6 +436,9 @@ def cog_validate(src_path):
         for e in errors:
             click.echo("- " + e, err=True)
 
+        return False
+    
+    if warnings and strict:
         return False
 
     return True

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -231,9 +231,15 @@ def create(
 
 @cogeo.command(short_help="Validate COGEO")
 @options.file_in_arg
-def validate(input):
+@click.option(
+    "--strict",
+    default=False,
+    is_flag=True,
+    help="Treat warnings as errors.",
+)
+def validate(input, strict):
     """Validate Cloud Optimized Geotiff."""
-    if cog_validate(input):
+    if cog_validate(input, strict=strict):
         click.echo("{} is a valid cloud optimized GeoTIFF".format(input))
     else:
         click.echo("{} is NOT a valid cloud optimized GeoTIFF".format(input))

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -232,10 +232,7 @@ def create(
 @cogeo.command(short_help="Validate COGEO")
 @options.file_in_arg
 @click.option(
-    "--strict",
-    default=False,
-    is_flag=True,
-    help="Treat warnings as errors.",
+    "--strict", default=False, is_flag=True, help="Treat warnings as errors.",
 )
 def validate(input, strict):
     """Validate Cloud Optimized Geotiff."""


### PR DESCRIPTION
Hello :hand:

I propose the addition of a "strict" flag to threat warnings as errors for the purposes of validation.

There are situations in which this might be desirable (eg. trying to determine whether a GeoTIFF is suited for streaming, overviews lacking are warnings, but affect performance significantly).