### PR TITLE
switch to morecantile for web optimized COG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,13 @@
 
 * switch to `morecantile` and update the web-optimized creation method to better match GDAL 3.2.
 * add `zoom_level_strategy` options to match GDAL 3.2 COG driver.
+* add `aligned_levels` (cli and api) to select the level of overview to align with the TMS grid.
 
 **Breaking Changes:**
 * removed `--latitude-adjustment/--global-maxzoom` option in the CLI
 * removed `latitude_adjustment` option in `rio_cogeo.cogeo.cog_translate`
 * updated **overview blocksize** to match the blocksize of the high resolution data (instead of default to 128)
+* for web-optimized COG, the highest overview level will be aligned with the TMS grid.
 
 ## 2.0.1 (2020-10-07)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.1.0 (TBD)
+
+* switch to `morecantile` and update the web-optimized creation method to better match GDAL 3.2.
+* add `zoom_level_strategy` options to match GDAL 3.2 COG driver.
+
+**Breaking Changes:**
+* removed `--latitude-adjustment/--global-maxzoom` option in the CLI
+* removed `latitude_adjustment` option in `rio_cogeo.cogeo.cog_translate`
+* updated **overview blocksize** to match the blocksize of the high resolution data (instead of default to 128)
+
 ## 2.0.1 (2020-10-07)
 
 * remove `pkg_resources` (https://github.com/pypa/setuptools/issues/510)

--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -11,11 +11,7 @@ Output dataset features:
 
 **Important**
 
-Because the mercator projection does not respect the distance, when working with
-multiple images covering different latitudes, you may want to use the *--global-maxzoom* option
-to create output dataset having the same MAX_ZOOM (raw data resolution).
-
-Because it will certainly create a larger file, a nodata value or alpha band should
+Because it will certainly create a larger file (with padding tiles on the side of the file), a nodata value, an alpha band or an internal mask should
 be present in the input dataset. If not the original data will be surrounded by black (0) data.
 
 
@@ -26,22 +22,10 @@ This can be updated by passing `--co BLOCKXSIZE=64 --co BLOCKYSIZE=64` options.
 
 **Web tiling optimization**
 
-if the input dataset is aligned to web mercator grid, the internal tile size
-should be equal to the web map tile size (256 or 512px). Dataset should be compressed.
+Creating a Web-Optimized COG, means you'll get a file which is perfectly aligned (bounds and internal tiles) with the mercator grid and with resolution (for the raw data and overview) which map the mercator zoom level resolution. This enable to reduce the number of GET request a dynamic tiling service needs to do to create a map tile from your COG.
 
 if the input dataset is not aligned to web mercator grid, the tiler will need
-to fetch multiple internal tiles. Because GDAL can merge range request, using
-small internal tiles (e.g 128) will reduce the number of byte transfered and
-minimized the useless bytes transfered.
-
-
-GDAL configuration to merge consecutive range requests
-
-```
-GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES
-GDAL_HTTP_MULTIPLEX=YES
-GDAL_HTTP_VERSION=2
-```
+to fetch multiple internal tiles.
 
 ## Overview levels
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -25,32 +25,27 @@ $ rio cogeo create --help
     Create Cloud Optimized Geotiff.
 
   Options:
-    -b, --bidx BIDX                  Band indexes to copy.
-    -p, --cog-profile [jpeg|webp|zstd|lzw|deflate|packbits|lzma|lerc|lerc_deflate|lerc_zstd|raw]
-                                     CloudOptimized GeoTIFF profile (default: deflate).
-    --nodata NUMBER|nan              Set nodata masking values for input dataset.
-    --add-mask                       Force output dataset creation with an internal mask (convert alpha band or nodata to mask).
-    --blocksize INTEGER             Overwrite profile's tile size.
-    -t, --dtype [ubyte|uint8|uint16|int16|uint32|int32|float32|float64] Output data type.
-    --overview-level INTEGER         Overview level (if not provided, appropriate overview level will be selected until the
-                                     smallest overview is smaller than the value of the internal blocksize)
-    --overview-resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss]
-                                     Overview creation resampling algorithm (default: nearest).
-    --overview-blocksize TEXT        Overview's internal tile size (default defined by GDAL_TIFF_OVR_BLOCKSIZE env or 128)
-    -w, --web-optimized              Create COGEO optimized for Web.
-    --latitude-adjustment / --global-maxzoom
-                                     Use dataset native mercator resolution for MAX_ZOOM calculation (linked to dataset
-                                     center latitude, default) or ensure MAX_ZOOM equality for multiple dataset accross latitudes.
-    -r, --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss]
-                                     Resampling algorithm (default: nearest). Will only be applied with the `--web-optimized` option.
-    --in-memory / --no-in-memory     Force processing raster in memory / not in memory (default: process in memory if smaller than 120 million pixels)
-    --allow-intermediate-compression Allow intermediate file compression to reduce memory/disk footprint.
-    --forward-band-tags              Forward band tags to output bands.
-    --threads THREADS                Number of worker threads for multi-threaded compression (default: ALL_CPUS)
-    --co, --profile NAME=VALUE       Driver specific creation options. See the documentation for the selected output driver for more information.
-    --config NAME=VALUE              GDAL configuration options.
-    -q, --quiet                      Remove progressbar and other non-error output.
-    --help                           Show this message and exit.
+    --bidx, -b                        Band indexes to copy.
+    --cog-profile, -p                 CloudOptimized GeoTIFF profile (default: deflate). [jpeg|webp|zstd|lzw|deflate|packbits|lzma|lerc|lerc_deflate|lerc_zstd|raw]
+    --nodata                          Set nodata masking values for input dataset.
+    --add-mask                        Force output dataset creation with an internal mask (convert alpha band or nodata to mask).
+    --blocksize                       Overwrite profile's tile size.
+    --dtype, -t                       Output data type. [ubyte|uint8|uint16|int16|uint32|int32|float32|float64]
+    --overview-level                  Overview level (if not provided, appropriate overview level will be selected until the smallest overview is smaller than the value of the internal blocksize)
+    --overview-resampling             Overview creation resampling algorithm (default: nearest).  [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss]
+    --overview-blocksize              Overview's internal tile size (default defined by GDAL_TIFF_OVR_BLOCKSIZE env or 128)
+    --web-optimized, -w               Create COGEO optimized for Web.
+    --zoom-level-strategy             Strategy to determine zoom level (default: auto).  [lower|upper|auto]
+    --aligned-levels                  Number of overview levels for which GeoTIFF tile and tiles defined in the tiling scheme match.
+    --resampling, -r                  Resampling algorithm (default: nearest). Will only be applied with the `--web-optimized` option.  [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss]
+    --in-memory / --no-in-memory      Force processing raster in memory / not in memory (default: process in memory if smaller than 120 million pixels)
+    --allow-intermediate-compression  Allow intermediate file compression to reduce memory/disk footprint.
+    --forward-band-tags               Forward band tags to output bands.
+    --threads                         Number of worker threads for multi-threaded compression (default: ALL_CPUS)
+    --co, --profile                   Driver specific creation options. See the documentation for the selected output driver for more information.
+    --config                          GDAL configuration options.
+    --quiet, -q                       Remove progressbar and other non-error output.
+    --help                            Show this message and exit.
 ```
 
 ### Validate

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -48,6 +48,7 @@ def cog_translate(  # noqa: C901
     overview_resampling: str = "nearest",
     web_optimized: bool = False,
     zoom_level_strategy: str = "auto",
+    aligned_levels: Optional[int] = None,
     resampling: str = "nearest",
     in_memory: Optional[bool] = None,
     config: Optional[Dict] = None,
@@ -81,14 +82,17 @@ def cog_translate(  # noqa: C901
         COGEO overview (decimation) level
     overview_resampling : str, optional (default: "nearest")
         Resampling algorithm for overviews
-    web_optimized: bool, option (default: False)
+    web_optimized: bool, optional (default: False)
         Create web-optimized cogeo.
-    zoom_level_strategy: str, option (default: auto)
+    zoom_level_strategy: str, optional (default: auto)
         Strategy to determine zoom level (same as in GDAL 3.2).
         LOWER will select the zoom level immediately below the theoretical computed non-integral zoom level, leading to subsampling.
         On the contrary, UPPER will select the immediately above zoom level, leading to oversampling.
         Defaults to AUTO which selects the closest zoom level.
         ref: https://gdal.org/drivers/raster/cog.html#raster-cog
+    aligned_levels: int, optional.
+        Number of overview levels for which GeoTIFF tile and tiles defined in the tiling scheme match.
+        Default is to use the maximum overview levels.
     resampling : str, optional (default: "nearest")
         Resampling algorithm.
     in_memory: bool, optional
@@ -181,6 +185,7 @@ def cog_translate(  # noqa: C901
                     tilesize=tilesize,
                     warp_resampling=resampling,
                     zoom_level_strategy=zoom_level_strategy,
+                    aligned_levels=aligned_levels,
                 )
                 vrt_params.update(**params)
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -9,6 +9,7 @@ from contextlib import ExitStack, contextmanager
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import click
+import morecantile
 import rasterio
 from rasterio.enums import ColorInterp
 from rasterio.enums import Resampling as ResamplingEnums
@@ -47,6 +48,7 @@ def cog_translate(  # noqa: C901
     overview_level: Optional[int] = None,
     overview_resampling: str = "nearest",
     web_optimized: bool = False,
+    tms: morecantile.TileMatrixSet = morecantile.tms.get("WebMercatorQuad"),
     zoom_level_strategy: str = "auto",
     aligned_levels: Optional[int] = None,
     resampling: str = "nearest",
@@ -84,6 +86,8 @@ def cog_translate(  # noqa: C901
         Resampling algorithm for overviews
     web_optimized: bool, optional (default: False)
         Create web-optimized cogeo.
+    tms: morecantile.TileMatrixSet, optional (default: "WebMercatorQuad")
+        TileMatrixSet to use for reprojection, resolution and alignment.
     zoom_level_strategy: str, optional (default: auto)
         Strategy to determine zoom level (same as in GDAL 3.2).
         LOWER will select the zoom level immediately below the theoretical computed non-integral zoom level, leading to subsampling.
@@ -186,6 +190,7 @@ def cog_translate(  # noqa: C901
                     warp_resampling=resampling,
                     zoom_level_strategy=zoom_level_strategy,
                     aligned_levels=aligned_levels,
+                    tms=tms,
                 )
                 vrt_params.update(**params)
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import click
 import rasterio
-from rasterio.crs import CRS
 from rasterio.enums import ColorInterp
 from rasterio.enums import Resampling as ResamplingEnums
 from rasterio.env import GDALVersion
@@ -23,8 +22,6 @@ from rio_cogeo import utils
 from rio_cogeo.errors import IncompatibleBlockRasterSize, LossyCompression
 
 IN_MEMORY_THRESHOLD = int(os.environ.get("IN_MEMORY_THRESHOLD", 10980 * 10980))
-WEB_MERCATOR_CRS = CRS.from_epsg(3857)
-WGS84_CRS = CRS.from_epsg(4326)
 
 
 @contextmanager
@@ -50,7 +47,7 @@ def cog_translate(  # noqa: C901
     overview_level: Optional[int] = None,
     overview_resampling: str = "nearest",
     web_optimized: bool = False,
-    latitude_adjustment: bool = True,
+    zoom_level_strategy: str = "auto",
     resampling: str = "nearest",
     in_memory: Optional[bool] = None,
     config: Optional[Dict] = None,
@@ -86,8 +83,12 @@ def cog_translate(  # noqa: C901
         Resampling algorithm for overviews
     web_optimized: bool, option (default: False)
         Create web-optimized cogeo.
-    latitude_adjustment: bool, option (default: True)
-        Use mercator meters for zoom calculation or ensure max zoom equality.
+    zoom_level_strategy: str, option (default: auto)
+        Strategy to determine zoom level (same as in GDAL 3.2).
+        LOWER will select the zoom level immediately below the theoretical computed non-integral zoom level, leading to subsampling.
+        On the contrary, UPPER will select the immediately above zoom level, leading to oversampling.
+        Defaults to AUTO which selects the closest zoom level.
+        ref: https://gdal.org/drivers/raster/cog.html#raster-cog
     resampling : str, optional (default: "nearest")
         Resampling algorithm.
     in_memory: bool, optional
@@ -178,8 +179,8 @@ def cog_translate(  # noqa: C901
                 params = utils.get_web_optimized_params(
                     src_dst,
                     tilesize=tilesize,
-                    latitude_adjustment=latitude_adjustment,
                     warp_resampling=resampling,
+                    zoom_level_strategy=zoom_level_strategy,
                 )
                 vrt_params.update(**params)
 

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -145,6 +145,11 @@ def cogeo():
     help="Strategy to determine zoom level. (default: auto).",
 )
 @click.option(
+    "--aligned-levels",
+    type=int,
+    help="Number of overview levels for which GeoTIFF tile and tiles defined in the tiling scheme match.",
+)
+@click.option(
     "--resampling",
     "-r",
     help="Resampling algorithm (default: nearest). Will only be applied with the `--web-optimized` option.",
@@ -203,6 +208,7 @@ def create(
     overview_blocksize,
     web_optimized,
     zoom_level_strategy,
+    aligned_levels,
     resampling,
     in_memory,
     allow_intermediate_compression,
@@ -245,6 +251,7 @@ def create(
         overview_resampling=overview_resampling,
         web_optimized=web_optimized,
         zoom_level_strategy=zoom_level_strategy,
+        aligned_levels=aligned_levels,
         resampling=resampling,
         in_memory=in_memory,
         config=config,

--- a/rio_cogeo/utils.py
+++ b/rio_cogeo/utils.py
@@ -1,108 +1,14 @@
 """rio_cogeo.utils: Utility functions."""
 
-import math
 from typing import Dict, Tuple
 
-import mercantile
+import morecantile
 from rasterio.crs import CRS
 from rasterio.enums import ColorInterp, MaskFlags
 from rasterio.enums import Resampling as ResamplingEnums
 from rasterio.rio.overview import get_maximum_overview_level
 from rasterio.transform import Affine
 from rasterio.warp import calculate_default_transform, transform_bounds
-from supermercado.burntiles import tile_extrema
-
-
-def _meters_per_pixel(zoom, lat=0.0, tilesize=256):
-    """
-    Return the pixel resolution for a given mercator tile zoom and lattitude.
-
-    Parameters
-    ----------
-    zoom: int
-        Mercator zoom level
-    lat: float, optional
-        Latitude in decimal degree (default: 0)
-    tilesize: int, optional
-        Mercator tile size (default: 256).
-
-    Returns
-    -------
-    Pixel resolution in meters
-
-    """
-    return (math.cos(lat * math.pi / 180.0) * 2 * math.pi * 6378137) / (
-        tilesize * 2 ** zoom
-    )
-
-
-def zoom_for_pixelsize(pixel_size, max_z=24, tilesize=256):
-    """
-    Get mercator zoom level corresponding to a pixel resolution.
-
-    Freely adapted from
-    https://github.com/OSGeo/gdal/blob/b0dfc591929ebdbccd8a0557510c5efdb893b852/gdal/swig/python/scripts/gdal2tiles.py#L294
-
-    Parameters
-    ----------
-    pixel_size: float
-        Pixel size
-    max_z: int, optional (default: 24)
-        Max mercator zoom level allowed
-    tilesize: int, optional
-        Mercator tile size (default: 256).
-
-    Returns
-    -------
-    Mercator zoom level corresponding to the pixel resolution
-
-    """
-    for z in range(max_z):
-        if pixel_size > _meters_per_pixel(z, 0, tilesize=tilesize):
-            return max(0, z - 1)  # We don't want to scale up
-
-    return max_z - 1
-
-
-def get_zooms(src_dst, lat=0.0, tilesize=256) -> Tuple[int, int]:
-    """
-    Calculate raster max zoom level.
-
-    Parameters
-    ----------
-    src: rasterio.io.DatasetReader
-        Rasterio io.DatasetReader object
-    lat: float, optional
-        Center latitude of the dataset. This is only needed in case you want to
-        apply latitude correction factor to ensure consitent maximum zoom level
-        (default: 0.0).
-    tilesize: int, optional
-        Mercator tile size (default: 256).
-
-    Returns
-    -------
-    max_zoom: int
-        Max zoom level.
-
-    """
-    dst_affine, w, h = calculate_default_transform(
-        src_dst.crs, "epsg:3857", src_dst.width, src_dst.height, *src_dst.bounds
-    )
-
-    native_resolution = max(abs(dst_affine[0]), abs(dst_affine[4]))
-
-    # Correction factor for web-mercator projection latitude distortion
-    latitude_correction_factor = math.cos(math.radians(lat))
-    corrected_resolution = native_resolution * latitude_correction_factor
-
-    max_zoom = zoom_for_pixelsize(corrected_resolution, tilesize=tilesize)
-    overview_level = get_maximum_overview_level(w, h, minsize=tilesize)
-
-    ovr_resolution = corrected_resolution * (2 ** overview_level)
-
-    min_zoom = zoom_for_pixelsize(ovr_resolution, tilesize=tilesize)
-
-    return (min_zoom, max_zoom)
 
 
 def has_alpha_band(src_dst):
@@ -127,12 +33,41 @@ def has_mask_band(src_dst):
     return False
 
 
+def get_zooms(
+    src_dst,
+    tilesize: int = 256,
+    tms: morecantile.TileMatrixSet = morecantile.tms.get("WebMercatorQuad"),
+    zoom_level_strategy: str = "auto",
+) -> Tuple[int, int]:
+    """Calculate raster min/max zoom level."""
+    if src_dst.crs != tms.crs:
+        aff, w, h = calculate_default_transform(
+            src_dst.crs, tms.crs, src_dst.width, src_dst.height, *src_dst.bounds,
+        )
+    else:
+        aff = list(src_dst.transform)
+        w = src_dst.width
+        h = src_dst.height
+
+    resolution = max(abs(aff[0]), abs(aff[4]))
+
+    max_zoom = tms.zoom_for_res(
+        resolution, max_z=30, zoom_level_strategy=zoom_level_strategy,
+    )
+
+    overview_level = get_maximum_overview_level(w, h, minsize=tilesize)
+    ovr_resolution = resolution * (2 ** overview_level)
+    min_zoom = tms.zoom_for_res(ovr_resolution, max_z=30)
+
+    return (min_zoom, max_zoom)
+
+
 def get_web_optimized_params(
     src_dst,
     tilesize=256,
-    latitude_adjustment: bool = True,
     warp_resampling: str = "nearest",
-    grid_crs=CRS.from_epsg(3857),
+    zoom_level_strategy: str = "auto",
+    tms: morecantile.TileMatrixSet = morecantile.tms.get("WebMercatorQuad"),
 ) -> Dict:
     """Return VRT parameters for a WebOptimized COG."""
     bounds = list(
@@ -140,24 +75,27 @@ def get_web_optimized_params(
             src_dst.crs, CRS.from_epsg(4326), *src_dst.bounds, densify_pts=21
         )
     )
-    center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
-
-    lat = 0 if latitude_adjustment else center[1]
-    _, max_zoom = get_zooms(src_dst, lat=lat, tilesize=tilesize)
-
-    extrema = tile_extrema(bounds, max_zoom)
-
-    left, _, _, top = mercantile.xy_bounds(
-        extrema["x"]["min"], extrema["y"]["min"], max_zoom
+    _, max_zoom = get_zooms(
+        src_dst, tilesize=tilesize, tms=tms, zoom_level_strategy=zoom_level_strategy,
     )
-    vrt_res = _meters_per_pixel(max_zoom, 0, tilesize=tilesize)
+
+    minimumTile = tms.tile(bounds[0], bounds[3], max_zoom)
+    maximumTile = tms.tile(bounds[2], bounds[1], max_zoom)
+    extrema = {
+        "x": {"min": minimumTile.x, "max": maximumTile.x + 1},
+        "y": {"min": minimumTile.y, "max": maximumTile.y + 1},
+    }
+
+    left, _, _, top = tms.xy_bounds(extrema["x"]["min"], extrema["y"]["min"], max_zoom)
+
+    vrt_res = tms._resolution(tms.matrix(max_zoom))
     vrt_transform = Affine(vrt_res, 0, left, 0, -vrt_res, top)
 
     vrt_width = (extrema["x"]["max"] - extrema["x"]["min"]) * tilesize
     vrt_height = (extrema["y"]["max"] - extrema["y"]["min"]) * tilesize
 
     return dict(
-        crs=grid_crs,
+        crs=tms.crs,
         transform=vrt_transform,
         width=vrt_width,
         height=vrt_height,

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ inst_reqs = [
     "click",
     "rasterio~=1.1",
     "numpy~=1.15",
-    "supermercado",
-    "mercantile~=1.1",
+    "morecantile~=2.1",
 ]
 
 extra_reqs = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -291,23 +291,22 @@ def test_cogeo_overviewTilesize(monkeypatch, runner):
 def test_cogeo_web(runner):
     """Should work as expected."""
     with runner.isolated_filesystem():
-        with pytest.warns(UserWarning):
-            result = runner.invoke(
-                cogeo,
-                ["create", raster_path_rgb, "output.tif", "--latitude-adjustment"],
-            )
-            assert not result.exception
-            assert result.exit_code == 0
-
-        with pytest.warns(UserWarning):
-            result = runner.invoke(
-                cogeo, ["create", raster_path_rgb, "output.tif", "--global-maxzoom"]
-            )
-            assert not result.exception
-            assert result.exit_code == 0
-
         result = runner.invoke(
             cogeo, ["create", raster_path_rgb, "output.tif", "--web-optimized"]
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            cogeo,
+            [
+                "create",
+                raster_path_rgb,
+                "output.tif",
+                "--web-optimized",
+                "--zoom-level-strategy",
+                "lower",
+            ],
         )
         assert not result.exception
         assert result.exit_code == 0


### PR DESCRIPTION
```
* switch to `morecantile` and update the web-optimized creation method to better match GDAL 3.2.
* add `zoom_level_strategy` options to match GDAL 3.2 COG driver.

**Breaking Changes:**
* removed `--latitude-adjustment/--global-maxzoom` option in the CLI
* removed `latitude_adjustment` option in `rio_cogeo.cogeo.cog_translate`
* updated **overview blocksize** to match the blocksize of the high resolution data (instead of default to 128)
```

To Do:
- [x] implement overview alignment https://github.com/OSGeo/gdal/blob/master/gdal/frmts/gtiff/cogdriver.cpp#L309-L349 🤷‍♂️ 
- [x] ~~add multi tms support~~
- [x] update docs