### PR TITLE
Fix docs edit link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: Cloud Optimized GeoTIFF (COG) creation and validation plugin f
 
 repo_name: 'cogeotiff/rio-cogeo'
 repo_url: 'https://github.com/cogeotiff/rio-cogeo'
-edit_uri: 'blob/master/docs/src/'
+edit_uri: 'blob/master/docs/'
 site_url: 'https://cogeotiff.github.io/rio-cogeo/'
 
 extra:


### PR DESCRIPTION
You don't have your docs in `docs/src/` in the repo, so the link is broken. This might be broken on other mkdocs configs too?