### PR TITLE
add colormap and additional_metadata in cog_translate api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Run Tox
         run: tox -e py
 
-      # Run pre-commit (only for python-3.7)
+      # Run pre-commit (only for python-3.8)
       - name: run pre-commit
-        if: matrix.python-version == 3.7
+        if: matrix.python-version == 3.8
         run: pre-commit run --all-files
 
       - name: Upload Results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,20 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
         args: ["--safe"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
       - id: isort
-        language_version: python3.7
+        language_version: python3.8
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.8.3
     hooks:
       - id: flake8
-        language_version: python3.7
+        language_version: python3.8
         args: [
             # E501 let black handle all line length decisions
             # W503 black conflicts with "line break before operator" rule
@@ -28,7 +28,7 @@ repos:
     rev: 5.1.1
     hooks:
       - id: pydocstyle
-        language_version: python3.7
+        language_version: python3.8
         args: [
             # Check for docstring presence only
             "--select=D1",
@@ -40,5 +40,5 @@ repos:
     rev: v0.770
     hooks:
       - id: mypy
-        language_version: python3.7
+        language_version: python3.8
         args: ["--no-strict-optional", "--ignore-missing-imports"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Release Notes
 
+# 2.1.3 (2021-03-03)
+
+* add **colormap** options in `cog_translate` to allow a user to set or update a colormap
+
+```python
+cmap = {0: (0, 0, 0, 0), 1: (1, 2, 3, 255)}
+cog_translate("boring.tif", "cogeo.tif", deflate_profile, colormap=cmap)
+with rasterio.open("cogeo.tif") as cog:
+    print(cog.colormap(1)[1])
+
+>>> (1, 2, 3, 255)
+```
+
+* add **additional_cog_metadata** options in `cog_translate` to allow the user to add more dataset metadatas
+
+```python
+cog_translate("boring.tif", "cogeo.tif", deflate_profile, additional_cog_metadata={"comments": "I made this tiff with rio-cogeo"})
+
+with rasterio.open("cogeo.tif") as cog:
+    print(cog.tags()["comment"])
+
+>>> "I made this tiff with rio-cogeo"
+```
+
 # 2.1.2 (2021-02-10)
 
 * remove useless path translation to pathlib and avoid side effect when using a URL (https://github.com/cogeotiff/rio-cogeo/issues/178)

--- a/rio_cogeo/errors.py
+++ b/rio_cogeo/errors.py
@@ -1,13 +1,17 @@
 """Rio-Cogeo Errors and Warnings."""
 
 
-class DeprecationWarning(UserWarning):
-    """Rio-cogeo module deprecations warning."""
-
-
 class LossyCompression(UserWarning):
     """Rio-cogeo module Lossy compression warning."""
 
 
 class IncompatibleBlockRasterSize(UserWarning):
     """Rio-cogeo module incompatible raster block/size warning."""
+
+
+class RioCogeoError(Exception):
+    """Base exception class."""
+
+
+class IncompatibleOptions(RioCogeoError):
+    """Rio-cogeo module incompatible options."""


### PR DESCRIPTION
This PR does

* add **colormap** options in `cog_translate` to allow a user to set or update a colormap

```python
cmap = {0: (0, 0, 0, 0), 1: (1, 2, 3, 255)}
cog_translate("boring.tif", "cogeo.tif", deflate_profile, colormap=cmap)
with rasterio.open("cogeo.tif") as cog:
    print(cog.colormap(1)[1])

>>> (1, 2, 3, 255)
```

* add **additional_cog_metadata** options in `cog_translate` to allow the user to add more dataset metadatas

```python
cog_translate("boring.tif", "cogeo.tif", deflate_profile, additional_cog_metadata={"comments": "I made this tiff with rio-cogeo"})

with rasterio.open("cogeo.tif") as cog:
    print(cog.tags()["comment"])

>>> "I made this tiff with rio-cogeo"
```