### PR TITLE
make WebOptimized COG similar to GDAL COG Driver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,12 @@ $ rio cogeo info out.tif | jq .Tags
 }
 ```
 
+* update `Web-Optimized` configuration to match GDAL COG Driver (https://github.com/cogeotiff/rio-cogeo/pull/193)
+
+  By default only the `raw` data will be aligned to the grid. To align overviews, the `aligned_levels` option can be used (wasn't really working in previous version).
+
+* `rio_cogeo.utils.get_web_optimized_params` has been refactored (https://github.com/cogeotiff/rio-cogeo/pull/193)
+
 # 2.1.4 (2021-03-31)
 
 * fix issue in validation when BLOCK_OFFSET_0 is None (https://github.com/cogeotiff/rio-cogeo/issues/182)

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -194,6 +194,7 @@ def cog_translate(  # noqa: C901
                 "dtype": dtype,
                 "width": src_dst.width,
                 "height": src_dst.height,
+                "resampling": ResamplingEnums[resampling],
             }
 
             if nodata is not None:
@@ -207,8 +208,6 @@ def cog_translate(  # noqa: C901
             if web_optimized:
                 params = utils.get_web_optimized_params(
                     src_dst,
-                    tilesize=tilesize,
-                    warp_resampling=resampling,
                     zoom_level_strategy=zoom_level_strategy,
                     aligned_levels=aligned_levels,
                     tms=tms,
@@ -385,7 +384,7 @@ def cog_validate(  # noqa: C901
                 )
 
             overviews = src.overviews(1)
-            if src.width > 512 or src.height > 512:
+            if src.width > 512 and src.height > 512:
                 if not src.is_tiled:
                     errors.append(
                         "The file is greater than 512xH or 512xW, but is not tiled"
@@ -500,7 +499,7 @@ def cog_validate(  # noqa: C901
 
         for ix, dec in enumerate(overviews):
             with rasterio.open(src_path, OVERVIEW_LEVEL=ix) as ovr_dst:
-                if ovr_dst.width >= 512 or ovr_dst.height >= 512:
+                if ovr_dst.width > 512 and ovr_dst.height > 512:
                     if not ovr_dst.is_tiled:
                         errors.append("Overview of index {} is not tiled".format(ix))
 

--- a/rio_cogeo/utils.py
+++ b/rio_cogeo/utils.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional, Tuple
 import morecantile
 from rasterio.crs import CRS
 from rasterio.enums import ColorInterp, MaskFlags
-from rasterio.enums import Resampling as ResamplingEnums
 from rasterio.rio.overview import get_maximum_overview_level
 from rasterio.transform import Affine
 from rasterio.warp import calculate_default_transform, transform_bounds
@@ -64,8 +63,6 @@ def get_zooms(
 
 def get_web_optimized_params(
     src_dst,
-    tilesize=256,
-    warp_resampling: str = "nearest",
     zoom_level_strategy: str = "auto",
     aligned_levels: Optional[int] = None,
     tms: morecantile.TileMatrixSet = morecantile.tms.get("WebMercatorQuad"),
@@ -76,39 +73,35 @@ def get_web_optimized_params(
             src_dst.crs, CRS.from_epsg(4326), *src_dst.bounds, densify_pts=21
         )
     )
-    min_zoom, max_zoom = get_zooms(
-        src_dst, tilesize=tilesize, tms=tms, zoom_level_strategy=zoom_level_strategy,
+
+    if src_dst.crs != tms.crs:
+        aff, w, h = calculate_default_transform(
+            src_dst.crs, tms.crs, src_dst.width, src_dst.height, *src_dst.bounds,
+        )
+    else:
+        aff = list(src_dst.transform)
+
+    resolution = max(abs(aff[0]), abs(aff[4]))
+
+    max_zoom = tms.zoom_for_res(
+        resolution, max_z=30, zoom_level_strategy=zoom_level_strategy,
     )
 
-    if aligned_levels is not None:
-        min_zoom = max_zoom - aligned_levels
+    aligned_levels = aligned_levels or 0
+    base_zoom = max_zoom - aligned_levels
 
-    ul_tile = tms.tile(bounds[0], bounds[3], min_zoom)
-    left, _, _, top = tms.xy_bounds(ul_tile.x, ul_tile.y, ul_tile.z)
+    ul_tile = tms.tile(bounds[0], bounds[3], base_zoom)
+    w, _, _, n = tms.xy_bounds(ul_tile.x, ul_tile.y, ul_tile.z)
 
     vrt_res = tms._resolution(tms.matrix(max_zoom))
-    vrt_transform = Affine(vrt_res, 0, left, 0, -vrt_res, top)
+    vrt_transform = Affine(vrt_res, 0, w, 0, -vrt_res, n)
 
-    lr_tile = tms.tile(bounds[2], bounds[1], min_zoom)
-    extrema = {
-        "x": {"min": ul_tile.x, "max": lr_tile.x + 1},
-        "y": {"min": ul_tile.y, "max": lr_tile.y + 1},
-    }
-    vrt_width = (
-        (extrema["x"]["max"] - extrema["x"]["min"])
-        * tilesize
-        * 2 ** (max_zoom - min_zoom)
-    )
-    vrt_height = (
-        (extrema["y"]["max"] - extrema["y"]["min"])
-        * tilesize
-        * 2 ** (max_zoom - min_zoom)
-    )
+    lr_tile = tms.tile(bounds[2], bounds[1], base_zoom)
+    e, _, _, s = tms.xy_bounds(lr_tile.x + 1, lr_tile.y + 1, lr_tile.z)
+
+    vrt_width = max(1, round((e - w) / vrt_transform.a))
+    vrt_height = max(1, round((s - n) / vrt_transform.e))
 
     return dict(
-        crs=tms.crs,
-        transform=vrt_transform,
-        width=vrt_width,
-        height=vrt_height,
-        resampling=ResamplingEnums[warp_resampling],
+        crs=tms.crs, transform=vrt_transform, width=vrt_width, height=vrt_height,
     )


### PR DESCRIPTION
This PR does:
- update `rio_cogeo.utils.get_web_optimized_params` function to match the configuration used in GDAL
- Fix wrong validation block (copied from GDAL)