### PR TITLE
add option to create COG using gdal COG driver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # 2.2.0 (TBD)
 
 * add pydantic models for `info` output (https://github.com/cogeotiff/rio-cogeo/issues/191)
+* add `use_cog_driver` option to create COG using new GDAL COG Driver (https://github.com/cogeotiff/rio-cogeo/pull/194)
 
 **Breaking Changes:**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,6 +42,7 @@ $ rio cogeo create --help
     --allow-intermediate-compression  Allow intermediate file compression to reduce memory/disk footprint.
     --forward-band-tags               Forward band tags to output bands.
     --threads                         Number of worker threads for multi-threaded compression (default: ALL_CPUS)
+    --use-cog-driver                  Use GDAL COG Driver (require GDAL>=3.1).
     --co, --profile                   Driver specific creation options. See the documentation for the selected output driver for more information.
     --config                          GDAL configuration options.
     --quiet, -q                       Remove progressbar and other non-error output.

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -70,7 +70,7 @@ def cog_translate(  # noqa: C901
     temporary_compression: str = "DEFLATE",
     colormap: Optional[Dict] = None,
     additional_cog_metadata: Optional[Dict] = None,
-    gdal_cog: bool = False,
+    use_gdal: bool = False,
 ):
     """
     Create Cloud Optimized Geotiff.
@@ -206,7 +206,7 @@ def cog_translate(  # noqa: C901
             if alpha:
                 vrt_params.update(dict(add_alpha=False))
 
-            if web_optimized and not gdal_cog:
+            if web_optimized and not use_gdal:
                 params = utils.get_web_optimized_params(
                     src_dst,
                     zoom_level_strategy=zoom_level_strategy,
@@ -319,7 +319,7 @@ def cog_translate(  # noqa: C901
                         ].name.upper()
                     )
                 )
-                if web_optimized and not gdal_cog:
+                if web_optimized and not use_gdal:
                     tags.update(dict(TILING_SCHEME="WebMercatorQuad"))
 
                 if additional_cog_metadata:
@@ -332,7 +332,7 @@ def cog_translate(  # noqa: C901
                 if not quiet:
                     click.echo("Writing output to: {}".format(dst_path), err=True)
 
-                if gdal_cog:
+                if use_gdal:
                     dst_kwargs["driver"] = "COG"
                     if web_optimized:
                         dst_kwargs["TILING_SCHEME"] = (

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -70,6 +70,7 @@ def cog_translate(  # noqa: C901
     temporary_compression: str = "DEFLATE",
     colormap: Optional[Dict] = None,
     additional_cog_metadata: Optional[Dict] = None,
+    gdal_cog: bool = False,
 ):
     """
     Create Cloud Optimized Geotiff.
@@ -205,7 +206,7 @@ def cog_translate(  # noqa: C901
             if alpha:
                 vrt_params.update(dict(add_alpha=False))
 
-            if web_optimized:
+            if web_optimized and not gdal_cog:
                 params = utils.get_web_optimized_params(
                     src_dst,
                     zoom_level_strategy=zoom_level_strategy,
@@ -318,7 +319,7 @@ def cog_translate(  # noqa: C901
                         ].name.upper()
                     )
                 )
-                if web_optimized:
+                if web_optimized and not gdal_cog:
                     tags.update(dict(TILING_SCHEME="WebMercatorQuad"))
 
                 if additional_cog_metadata:
@@ -331,7 +332,31 @@ def cog_translate(  # noqa: C901
                 if not quiet:
                     click.echo("Writing output to: {}".format(dst_path), err=True)
 
-                copy(tmp_dst, dst_path, copy_src_overviews=True, **dst_kwargs)
+                if gdal_cog:
+                    dst_kwargs["driver"] = "COG"
+                    if web_optimized:
+                        dst_kwargs["TILING_SCHEME"] = (
+                            "GoogleMapsCompatible"
+                            if tms.identifier == "WebMercatorQuad"
+                            else tms.identifier
+                        )
+
+                    dst_kwargs["zoom_level_strategy"] = zoom_level_strategy
+                    dst_kwargs["overview_resampling"] = overview_resampling
+                    dst_kwargs["warp_resampling"] = resampling
+                    if aligned_levels is not None:
+                        dst_kwargs["aligned_levels"] = aligned_levels
+
+                    dst_kwargs["blocksize"] = tilesize
+                    dst_kwargs.pop("blockxsize", None)
+                    dst_kwargs.pop("blockysize", None)
+                    dst_kwargs.pop("tiled", None)
+                    dst_kwargs.pop("interleave", None)
+                    dst_kwargs.pop("photometric", None)
+                    copy(tmp_dst, dst_path, **dst_kwargs)
+
+                else:
+                    copy(tmp_dst, dst_path, copy_src_overviews=True, **dst_kwargs)
 
 
 def cog_validate(  # noqa: C901

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -70,7 +70,7 @@ def cog_translate(  # noqa: C901
     temporary_compression: str = "DEFLATE",
     colormap: Optional[Dict] = None,
     additional_cog_metadata: Optional[Dict] = None,
-    use_gdal: bool = False,
+    use_cog_driver: bool = False,
 ):
     """
     Create Cloud Optimized Geotiff.
@@ -131,6 +131,8 @@ def cog_translate(  # noqa: C901
         Overwrite or add a colormap to the output COG.
     additional_cog_metadata: dict, optional
         Additional dataset metadata to add to the COG.
+    use_cog_driver: bool, optional (default: False)
+        Use GDAL COG driver if set to True. COG driver is available starting with GDAL 3.1.
 
     """
     if isinstance(indexes, int):
@@ -206,7 +208,7 @@ def cog_translate(  # noqa: C901
             if alpha:
                 vrt_params.update(dict(add_alpha=False))
 
-            if web_optimized and not use_gdal:
+            if web_optimized and not use_cog_driver:
                 params = utils.get_web_optimized_params(
                     src_dst,
                     zoom_level_strategy=zoom_level_strategy,
@@ -319,7 +321,7 @@ def cog_translate(  # noqa: C901
                         ].name.upper()
                     )
                 )
-                if web_optimized and not use_gdal:
+                if web_optimized and not use_cog_driver:
                     tags.update(dict(TILING_SCHEME="WebMercatorQuad"))
 
                 if additional_cog_metadata:
@@ -332,7 +334,7 @@ def cog_translate(  # noqa: C901
                 if not quiet:
                     click.echo("Writing output to: {}".format(dst_path), err=True)
 
-                if use_gdal:
+                if use_cog_driver:
                     dst_kwargs["driver"] = "COG"
                     if web_optimized:
                         dst_kwargs["TILING_SCHEME"] = (
@@ -353,6 +355,7 @@ def cog_translate(  # noqa: C901
                     dst_kwargs.pop("tiled", None)
                     dst_kwargs.pop("interleave", None)
                     dst_kwargs.pop("photometric", None)
+
                     copy(tmp_dst, dst_path, **dst_kwargs)
 
                 else:

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -181,7 +181,7 @@ def cogeo():
     default="ALL_CPUS",
     help="Number of worker threads for multi-threaded compression (default: ALL_CPUS)",
 )
-@click.option("--gdal-cog", help="Use GDAL COG Driver.", is_flag=True, default=False)
+@click.option("--use-gdal", help="Use GDAL COG Driver.", is_flag=True, default=False)
 @options.creation_options
 @click.option(
     "--config",
@@ -214,7 +214,7 @@ def create(
     allow_intermediate_compression,
     forward_band_tags,
     threads,
-    gdal_cog,
+    use_gdal,
     creation_options,
     config,
     quiet,
@@ -258,7 +258,7 @@ def create(
         config=config,
         allow_intermediate_compression=allow_intermediate_compression,
         forward_band_tags=forward_band_tags,
-        gdal_cog=gdal_cog,
+        use_gdal=use_gdal,
         quiet=quiet,
     )
 

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -181,7 +181,12 @@ def cogeo():
     default="ALL_CPUS",
     help="Number of worker threads for multi-threaded compression (default: ALL_CPUS)",
 )
-@click.option("--use-gdal", help="Use GDAL COG Driver.", is_flag=True, default=False)
+@click.option(
+    "--use-cog-driver",
+    help="Use GDAL COG Driver (require GDAL>=3.1).",
+    is_flag=True,
+    default=False,
+)
 @options.creation_options
 @click.option(
     "--config",
@@ -214,7 +219,7 @@ def create(
     allow_intermediate_compression,
     forward_band_tags,
     threads,
-    use_gdal,
+    use_cog_driver,
     creation_options,
     config,
     quiet,
@@ -258,7 +263,7 @@ def create(
         config=config,
         allow_intermediate_compression=allow_intermediate_compression,
         forward_band_tags=forward_band_tags,
-        use_gdal=use_gdal,
+        use_cog_driver=use_cog_driver,
         quiet=quiet,
     )
 

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -181,6 +181,7 @@ def cogeo():
     default="ALL_CPUS",
     help="Number of worker threads for multi-threaded compression (default: ALL_CPUS)",
 )
+@click.option("--gdal-cog", help="Use GDAL COG Driver.", is_flag=True, default=False)
 @options.creation_options
 @click.option(
     "--config",
@@ -213,6 +214,7 @@ def create(
     allow_intermediate_compression,
     forward_band_tags,
     threads,
+    gdal_cog,
     creation_options,
     config,
     quiet,
@@ -256,6 +258,7 @@ def create(
         config=config,
         allow_intermediate_compression=allow_intermediate_compression,
         forward_band_tags=forward_band_tags,
+        gdal_cog=gdal_cog,
         quiet=quiet,
     )
 

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -537,7 +537,7 @@ def test_gdal_cog(src_path, runner):
     """Test GDAL COG."""
     with runner.isolated_filesystem():
         cog_translate(
-            src_path, "cogeo.tif", cog_profiles.get("raw"), quiet=True, gdal_cog=True
+            src_path, "cogeo.tif", cog_profiles.get("raw"), quiet=True, use_gdal=True
         )
         assert cog_validate("cogeo.tif")
 
@@ -551,7 +551,7 @@ def test_gdal_cog_compare(runner):
 
         # rio cogeo GDAL COG
         cog_translate(
-            raster_path_rgba, "gdalcogeo.tif", profile.copy(), quiet=True, gdal_cog=True
+            raster_path_rgba, "gdalcogeo.tif", profile.copy(), quiet=True, use_gdal=True
         )
 
         # pure COG
@@ -587,7 +587,7 @@ def test_gdal_cog_compareWeb(runner):
             "gdalcogeo.tif",
             profile.copy(),
             quiet=True,
-            gdal_cog=True,
+            use_gdal=True,
             web_optimized=True,
         )
 

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -537,7 +537,11 @@ def test_gdal_cog(src_path, runner):
     """Test GDAL COG."""
     with runner.isolated_filesystem():
         cog_translate(
-            src_path, "cogeo.tif", cog_profiles.get("raw"), quiet=True, use_gdal=True
+            src_path,
+            "cogeo.tif",
+            cog_profiles.get("raw"),
+            quiet=True,
+            use_cog_driver=True,
         )
         assert cog_validate("cogeo.tif")
 
@@ -551,7 +555,11 @@ def test_gdal_cog_compare(runner):
 
         # rio cogeo GDAL COG
         cog_translate(
-            raster_path_rgba, "gdalcogeo.tif", profile.copy(), quiet=True, use_gdal=True
+            raster_path_rgba,
+            "gdalcogeo.tif",
+            profile.copy(),
+            quiet=True,
+            use_cog_driver=True,
         )
 
         # pure COG
@@ -587,7 +595,7 @@ def test_gdal_cog_compareWeb(runner):
             "gdalcogeo.tif",
             profile.copy(),
             quiet=True,
-            use_gdal=True,
+            use_cog_driver=True,
             web_optimized=True,
         )
 


### PR DESCRIPTION
To create a COG using GDAL>3.1, a user can just do `gdal_translate -of COG in.tif out.tif` or `rasterio.shutils.copy("in.tif", "ou.tif", driver="COG")` but rio-cogeo adds more options:
- setting nodata
- updating file tags
- translating nodata/alpha to internal mask
- selecting the number of overview
- setting colormap 

☝️ in order to do this using gdal cli you'll need to user either gdal_translate or gdalwarp and maybe gdal_edit. 

creating COG (gdal driver) might not be the most efficient but 🤷