### PR TITLE
Gdal like tiling scheme tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,8 @@ assert isinstance(info, rio_cogeo.models.Info)
 assert info.GEO.CRS
 ```
 
-* add `TILING_SCHEME` in COG metadata when creating WebOptimized COG (https://github.com/cogeotiff/rio-cogeo/pull/192)
+* add `TILING SCHEME` in dataset namespaced metadata when creating WebOptimized COG (https://github.com/cogeotiff/rio-cogeo/pull/193)
+* add more info in rio cogeo info `Tags` (https://github.com/cogeotiff/rio-cogeo/pull/193)
 
 ```python
 # before
@@ -38,9 +39,20 @@ $ rio cogeo info out.tif | jq .Tags
 $ rio cogeo create in.tif out.tif -w
 $ rio cogeo info out.tif | jq .Tags
 >> {
-  "AREA_OR_POINT": "Area",
-  "OVR_RESAMPLING_ALG": "NEAREST",
-  "TILING_SCHEME": "WebMercatorQuad"
+  "Image Metadata": {
+    "AREA_OR_POINT": "Area",
+    "DataType": "Generic",
+    "OVR_RESAMPLING_ALG": "NEAREST"
+  },
+  "Image Structure": {
+    "COMPRESSION": "DEFLATE",
+    "INTERLEAVE": "BAND",
+    "LAYOUT": "COG"
+  },
+  "Tiling Scheme": {
+    "NAME": "WEBMERCATORQUAD",
+    "ZOOM_LEVEL": "17"
+  }
 }
 ```
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -572,7 +572,13 @@ def cog_info(src_path: Union[str, pathlib.PurePath], **kwargs: Any) -> models.In
         compression = src_dst.compression.value if src_dst.compression else None
         colorspace = src_dst.photometric.value if src_dst.photometric else None
         overviews = src_dst.overviews(1)
-        tags = src_dst.tags()
+
+        tags = {"Image Metadata": src_dst.tags()}
+        namespaces = src_dst.tag_namespaces()
+        for ns in namespaces:
+            if ns in ["DERIVED_SUBDATASETS"]:
+                continue
+            tags.update({str.title(ns).replace("_", " "): src_dst.tags(ns=ns)})
 
         try:
             colormap = src_dst.colormap(1)

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -321,11 +321,25 @@ def cog_translate(  # noqa: C901
                         ].name.upper()
                     )
                 )
-                if web_optimized and not use_cog_driver:
-                    tags.update(dict(TILING_SCHEME="WebMercatorQuad"))
-
                 if additional_cog_metadata:
                     tags.update(**additional_cog_metadata)
+
+                if web_optimized and not use_cog_driver:
+                    dst_kwargs.update(
+                        {
+                            "@TILING_SCHEME_NAME": "WebMercatorQuad",
+                            "@TILING_SCHEME_ZOOM_LEVEL": tms.zoom_for_res(
+                                max(tmp_dst.res),
+                                max_z=30,
+                                zoom_level_strategy=zoom_level_strategy,
+                            ),
+                        }
+                    )
+
+                    if aligned_levels:
+                        dst_kwargs.update(
+                            {"@TILING_SCHEME_ALIGNED_LEVELS": aligned_levels}
+                        )
 
                 tmp_dst.update_tags(**tags)
                 tmp_dst._set_all_scales([vrt_dst.scales[b - 1] for b in indexes])

--- a/rio_cogeo/models.py
+++ b/rio_cogeo/models.py
@@ -62,5 +62,5 @@ class Info(BaseModel):
     COG_warnings: Optional[Sequence[str]]
     Profile: Profile
     GEO: Geo
-    Tags: Dict[str, Any]
+    Tags: Dict[str, Dict]
     IFD: Sequence[IFD]

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -313,11 +313,11 @@ def info(input, to_json):
     {click.style("ColorMap:", bold=True):<{sep}} {metadata.Profile.ColorMap}
     {click.style("ColorInterp:", bold=True):<{sep}} {metadata.Profile.ColorInterp}
     {click.style("Scales:", bold=True):<{sep}} {metadata.Profile.Scales}
-    {click.style("Offsets:", bold=True):<{sep}} {metadata.Profile.Offsets}
+    {click.style("Offsets:", bold=True):<{sep}} {metadata.Profile.Offsets}"""
+        )
 
-{click.style('Image Metadata', bold=True)}
-    {create_tag_table(metadata.Tags, sep+5)}
-
+        click.echo(
+            f"""
 {click.style('Geo', bold=True)}
     {click.style("Crs:", bold=True):<{sep}} {metadata.GEO.CRS}
     {click.style("Origin:", bold=True):<{sep}} {metadata.GEO.Origin}
@@ -326,6 +326,16 @@ def info(input, to_json):
     {click.style("MinZoom:", bold=True):<{sep}} {metadata.GEO.MinZoom}
     {click.style("MaxZoom:", bold=True):<{sep}} {metadata.GEO.MaxZoom}"""
         )
+
+        for ns, values in metadata.Tags.items():
+            click.echo(
+                f"""
+{click.style(ns, bold=True)}"""
+            )
+            for key, val in values.items():
+                click.echo(
+                    f"""    {click.style(key, underline=True, bold=True)}: {val}"""
+                )
 
         click.echo(
             f"""

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -505,6 +505,8 @@ def test_cog_info():
     assert info.GEO.MinZoom == 5
     assert info.GEO.MaxZoom == 11
     assert len(info.IFD) == 6
+    assert info.Tags["Image Metadata"]
+    assert info.Tags["Image Structure"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -113,7 +113,23 @@ def test_cog_translate_web():
                 lrTile = tms.xy_bounds(tms.tile(bounds[2], bounds[1], max_zoom))
                 assert out_dst.bounds.right == lrTile.right
                 assert round(out_dst.bounds.bottom, 6) == round(lrTile.bottom, 6)
-                assert out_dst.tags()["TILING_SCHEME"] == "WebMercatorQuad"
+                assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "WEBMERCATORQUAD"
+                assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"]
+                assert not out_dst.tags(ns="TILING_SCHEME").get("ALIGNED_LEVELS")
+
+        cog_translate(
+            raster_path_web,
+            "cogeo.tif",
+            web_profile,
+            quiet=True,
+            web_optimized=True,
+            config=config,
+            aligned_levels=4,
+        )
+        with rasterio.open("cogeo.tif") as out_dst:
+            assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "WEBMERCATORQUAD"
+            assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"]
+            assert out_dst.tags(ns="TILING_SCHEME")["ALIGNED_LEVELS"] == "4"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")


### PR DESCRIPTION
closes #192 

This PR does 
- [x] Use same namespaced metadata for Tiling Scheme as the GDAL COG driver
- [x] Update the `Info` Model to make Tags a Dict of dict 

```bash
rio cogeo info web.tif --json | jq .Tags
{
  "Image Metadata": {
    "AREA_OR_POINT": "Area",
    "DataType": "Generic",
    "OVR_RESAMPLING_ALG": "NEAREST"
  },
  "Image Structure": {
    "COMPRESSION": "DEFLATE",
    "INTERLEAVE": "BAND",
    "LAYOUT": "COG"
  },
  "Tiling Scheme": {
    "NAME": "WEBMERCATORQUAD",
    "ZOOM_LEVEL": "17"
  }
}
```