### PR TITLE
materialize nodata/alpha to mask when using JPEG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-# 2.2.0 (TBD)
+# 2.2.0 (2021-05-18)
 
 * add pydantic models for `info` output (https://github.com/cogeotiff/rio-cogeo/issues/191)
 * add `use_cog_driver` option to create COG using new GDAL COG Driver (https://github.com/cogeotiff/rio-cogeo/pull/194)
@@ -61,6 +61,25 @@ $ rio cogeo info out.tif | jq .Tags
   By default only the `raw` data will be aligned to the grid. To align overviews, the `aligned_levels` option can be used (wasn't really working in previous version).
 
 * `rio_cogeo.utils.get_web_optimized_params` has been refactored (https://github.com/cogeotiff/rio-cogeo/pull/193)
+
+* `cog_translate` will now materialize **Nodata or Alpha band** to an internal **mask** automatically for JPEG compresssed output (https://github.com/cogeotiff/rio-cogeo/pull/196)
+
+```python
+# before
+cog_translate(raster_path_rgba, "cogeo.tif", jpeg_profile)
+with rasterio.open("cogeo.tif") as src:
+    assert src.count == 4
+    assert src.compression.value == "JPEG"
+    assert has_alpha_band(src)
+    assert not has_mask_band(src)
+
+# now
+cog_translate(raster_path_rgba, "cogeo.tif", jpeg_profile)
+with rasterio.open("cogeo.tif") as src:
+    assert src.count == 3
+    assert src.compression.value == "JPEG"
+    assert has_mask_band(src)
+```
 
 # 2.1.4 (2021-03-31)
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -131,6 +131,8 @@ def cog_translate(  # noqa: C901
         Use GDAL COG driver if set to True. COG driver is available starting with GDAL 3.1.
 
     """
+    dst_kwargs = dst_kwargs.copy()
+
     if isinstance(indexes, int):
         indexes = (indexes,)
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -22,11 +22,7 @@ from rasterio.shutil import copy
 from rasterio.vrt import WarpedVRT
 
 from rio_cogeo import models, utils
-from rio_cogeo.errors import (
-    IncompatibleBlockRasterSize,
-    IncompatibleOptions,
-    LossyCompression,
-)
+from rio_cogeo.errors import IncompatibleBlockRasterSize, IncompatibleOptions
 
 IN_MEMORY_THRESHOLD = int(os.environ.get("IN_MEMORY_THRESHOLD", 10980 * 10980))
 
@@ -160,12 +156,16 @@ def cog_translate(  # noqa: C901
 
             if not add_mask and (
                 (nodata is not None or alpha)
-                and dst_kwargs.get("compress") in ["JPEG", "jpeg"]
+                and dst_kwargs.get("compress", "").lower() == "jpeg"
             ):
                 warnings.warn(
-                    "Using lossy compression with Nodata or Alpha band "
-                    "can results in unwanted artefacts.",
-                    LossyCompression,
+                    "Nodata/Alpha band will be translated to an internal mask band.",
+                )
+                add_mask = True
+                indexes = (
+                    utils.non_alpha_indexes(src_dst)
+                    if len(indexes) not in [1, 3]
+                    else indexes
                 )
 
             tilesize = min(int(dst_kwargs["blockxsize"]), int(dst_kwargs["blockysize"]))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,6 @@ import os
 import pytest
 import rasterio
 
-from rio_cogeo.errors import LossyCompression
 from rio_cogeo.scripts.cli import cogeo
 from rio_cogeo.utils import has_mask_band
 
@@ -124,7 +123,7 @@ def test_cogeo_invalidThread(runner):
 def test_cogeo_validnodata(runner):
     """Should work as expected."""
     with runner.isolated_filesystem():
-        with pytest.warns(LossyCompression):
+        with pytest.warns(UserWarning):
             result = runner.invoke(
                 cogeo,
                 [
@@ -140,8 +139,8 @@ def test_cogeo_validnodata(runner):
             assert not result.exception
             assert result.exit_code == 0
             with rasterio.open("output.tif") as src:
-                assert src.nodata == 0
-                assert not has_mask_band(src)
+                assert not src.nodata
+                assert has_mask_band(src)
 
         result = runner.invoke(
             cogeo,


### PR DESCRIPTION
closes #188 

This PR removes the `LossyCompression` compression warning when user used JPEG + nodata/alpha and add automatic translation to internal mask