### PR TITLE
use TextIO instead of str for click progressbar output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+# 2.2.3 (2021-06-18)
+
+* use opened file for click progressbar (https://github.com/cogeotiff/rio-cogeo/pull/204)
+
 # 2.2.2 (2021-06-01)
 
 * Add dictionary access to `Info` model (author @geospatial-jeff, https://github.com/cogeotiff/rio-cogeo/pull/201)

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -285,7 +285,8 @@ def cog_translate(  # noqa: C901
 
                 if not quiet:
                     click.echo("Reading input: {}".format(source), err=True)
-                fout = os.devnull if quiet else sys.stderr
+
+                fout = ctx.enter_context(open(os.devnull, "w")) if quiet else sys.stderr
                 with click.progressbar(wind, file=fout, show_percent=True) as windows:  # type: ignore
                     for _, w in windows:
                         matrix = vrt_dst.read(window=w, indexes=indexes)


### PR DESCRIPTION
closes #203 

as mentioned by @ghelobytes, new version of click expects a TextIO for the `file` argument. Before we were just lucky that it worked. 