### PR TITLE
Add new parameter to `cog_validation`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+# 2.2.4 (TBD)
+
+* add `overview_internal` boolean parameter to `cog_validate`-function (https://github.com/cogeotiff/rio-cogeo/pull/205)
+
 # 2.2.3 (2021-06-18)
 
 * use opened file for click progressbar (https://github.com/cogeotiff/rio-cogeo/pull/204)

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -380,7 +380,7 @@ def cog_translate(  # noqa: C901
 
 
 def cog_validate(  # noqa: C901
-    src_path: Union[str, pathlib.PurePath], strict: bool = False, quiet: bool = False
+    src_path: Union[str, pathlib.PurePath], strict: bool = False, quiet: bool = False, overview_internal: bool = False
 ) -> Tuple[bool, List[str], List[str]]:
     """
     Validate Cloud Optimized Geotiff.
@@ -396,6 +396,8 @@ def cog_validate(  # noqa: C901
         Treat warnings as errors
     quiet: bool
         Remove standard outputs
+    overview_internal: bool
+        Speed up validation when overviews are not in external .ovr-files
 
     Returns
     -------
@@ -414,7 +416,7 @@ def cog_validate(  # noqa: C901
     if not GDALVersion.runtime().at_least("2.2"):
         raise Exception("GDAL 2.2 or above required")
 
-    config = dict(GDAL_DISABLE_READDIR_ON_OPEN="FALSE")
+    config = dict(GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR" if overview_internal else "FALSE")
     with rasterio.Env(**config):
         with rasterio.open(src_path) as src:
             if not src.driver == "GTiff":


### PR DESCRIPTION
Speeds up validation when there are many GeoTIFFs with the same S3 bucket prefix and all of them are known not to have external overviews.