### PR TITLE
allow external config for cog_validate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+# 2.3.0 (TBD)
+
+* allow external configuration (GDAL Env) for `cog_validate` (https://github.com/cogeotiff/rio-cogeo/pull/206)
+
+  ```python
+  from rio_cogeo import cog_validate
+
+  assert cog_validate("cog.tif", congig={"GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR"})[0]
+  ```
+
+  In previous version we were forcing `GDAL_DISABLE_READDIR_ON_OPEN=FALSE` in `cog_validate` function to check for external overviews.
+
+  Starting with version 2.3, it's up to the user to set the wanted GDAL configuration (e.g `EMPTY_DIR`: no external file check, `FALSE`: check for external files)
+
+
 # 2.2.3 (2021-06-18)
 
 * use opened file for click progressbar (https://github.com/cogeotiff/rio-cogeo/pull/204)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,12 +58,14 @@ Usage: rio cogeo validate [OPTIONS] INPUT
   Validate Cloud Optimized Geotiff.
 
 Options:
-  --strict  Treat warnings as errors.
-  --help    Show this message and exit.
+  --strict             Treat warnings as errors.
+  --config NAME=VALUE  GDAL configuration options.
+  --help               Show this message and exit.
 ```
 
 The `strict` options will treat warnings (e.g missing overviews) as errors.
 
+Using the `--config` option can be useful to restrict GDAL environement. By default GDAL will check for external files (such as overviews), which could make a COG invalid. To force GDAL to only consider the input file you can use `--config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR.
 
 ### Info
 (extented version or `rio info`).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,6 +67,11 @@ The `strict` options will treat warnings (e.g missing overviews) as errors.
 
 Using the `--config` option can be useful to restrict GDAL environement. By default GDAL will check for external files (such as overviews), which could make a COG invalid. To force GDAL to only consider the input file you can use `--config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR.
 
+e.g:
+```
+$ rio cogeo validate s3://bucket/geo.tif --config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR --config AWS_NO_SIGN_REQUEST=YES
+```
+
 ### Info
 (extented version or `rio info`).
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -380,7 +380,10 @@ def cog_translate(  # noqa: C901
 
 
 def cog_validate(  # noqa: C901
-    src_path: Union[str, pathlib.PurePath], strict: bool = False, quiet: bool = False
+    src_path: Union[str, pathlib.PurePath],
+    strict: bool = False,
+    config: Optional[Dict] = None,
+    quiet: bool = False,
 ) -> Tuple[bool, List[str], List[str]]:
     """
     Validate Cloud Optimized Geotiff.
@@ -411,10 +414,11 @@ def cog_validate(  # noqa: C901
     warnings = []
     details: Dict[str, Any] = {}
 
+    config = config or {}
+
     if not GDALVersion.runtime().at_least("2.2"):
         raise Exception("GDAL 2.2 or above required")
 
-    config = dict(GDAL_DISABLE_READDIR_ON_OPEN="FALSE")
     with rasterio.Env(**config):
         with rasterio.open(src_path) as src:
             if not src.driver == "GTiff":

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -273,9 +273,17 @@ def create(
 @cogeo.command(short_help="Validate COGEO")
 @options.file_in_arg
 @click.option("--strict", default=False, is_flag=True, help="Treat warnings as errors.")
-def validate(input, strict):
+@click.option(
+    "--config",
+    "config",
+    metavar="NAME=VALUE",
+    multiple=True,
+    callback=options._cb_key_val,
+    help="GDAL configuration options.",
+)
+def validate(input, strict, config):
     """Validate Cloud Optimized Geotiff."""
-    is_valid, _, _ = cog_validate(input, strict=strict)
+    is_valid, _, _ = cog_validate(input, strict=strict, config=config)
     if is_valid:
         click.echo("{} is a valid cloud optimized GeoTIFF".format(input))
     else:


### PR DESCRIPTION
 Before we were forcing `GDAL_DISABLE_READDIR_ON_OPEN=FALSE` for validation. With this PR we let the user decide what env to set. 

## TODO 
- [ ] add a note about the link between env variable and validation result


cc @JoakimJoensuu