### PR TITLE
update `click` version requirement to `>=7.0` to make sure `click.Choice` supports the `case_sensitive` option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-# 2.3.0 (2021-0625)
+# 2.3.1 (2021-07-06)
+
+* update `click` version requirement to `>=7.0` to make sure `click.Choice` supports the `case_sensitive` option.
+
+# 2.3.0 (2021-06-25)
 
 * allow external configuration (GDAL Env) for `cog_validate` (https://github.com/cogeotiff/rio-cogeo/pull/206)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
+click>=7.0
 numpy~=1.15
 rasterio>=1.1
 morecantile>=2.1,<2.2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 # Runtime requirements.
 inst_reqs = [
-    "click",
+    "click>=7.0",
     "rasterio>=1.1",
     "numpy~=1.15",
     "morecantile>=2.1,<2.2",


### PR DESCRIPTION
ref https://github.com/cogeotiff/rio-cogeo/issues/208