### PR TITLE
raise warning when using incompatible options for GDAL COG driver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-# 2.3.2 (2021-07-16)
+# NEXT (TBD)
 
 * raise warning when using incompatible options for GDAL COG driver (https://github.com/cogeotiff/rio-cogeo/pull/212)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+# 2.3.2 (2021-07-16)
+
+* raise warning when using incompatible options for GDAL COG driver (https://github.com/cogeotiff/rio-cogeo/pull/212)
+
 # 2.3.1 (2021-07-06)
 
 * update `click` version requirement to `>=7.0` to make sure `click.Choice` supports the `case_sensitive` option.

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -360,6 +360,11 @@ def cog_translate(  # noqa: C901
                             else tms.identifier
                         )
 
+                        if add_mask and dst_kwargs.get("compress", "") != "JPEG":
+                            warnings.warn(
+                                "With GDAL COG driver, mask band will be translated to an alpha band."
+                            )
+
                     dst_kwargs["zoom_level_strategy"] = zoom_level_strategy
                     dst_kwargs["overview_resampling"] = overview_resampling
                     dst_kwargs["warp_resampling"] = resampling

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -637,3 +637,19 @@ def test_gdal_cog_compareWeb(runner):
             "cog.tif"
         ) as cog:
             assert cog.meta == gdalcogeo.meta
+
+
+def test_gdal_cog_web_mask(runner):
+    """Raise a warning for specific mask/compression/web combination."""
+    with runner.isolated_filesystem():
+        with pytest.warns(UserWarning):
+            cog_translate(
+                raster_path_rgb,
+                "cogeo.tif",
+                cog_profiles.get("deflate"),
+                use_cog_driver=True,
+                web_optimized=True,
+                add_mask=True,
+                quiet=True,
+            )
+            assert cog_validate("cogeo.tif")


### PR DESCRIPTION
closes #211 

see https://github.com/cogeotiff/rio-cogeo/issues/211#issuecomment-881501584

cc @drnextgis 