### PR TITLE
allow non-geotiff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+# 3.3.0 (2022-06-16)
+
+* allow **non-GeoTIFF** in `cog_validate`
+* allow `config` option in `rio cogeo info` CLI
+
 # 3.2.0 (2022-04-05)
 
 * Switch to `pyproject.toml` (https://github.com/cogeotiff/rio-cogeo/pull/232)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,11 @@ $ git clone https://github.com/cogeotiff/rio-cogeo.git
 $ cd rio-cogeo
 $ pip install -e .["test","dev"]
 ```
+You can then run the tests with the following command:
+
+```sh
+python -m pytest --cov rio_cogeo --cov-report term-missing
+```
 
 ## pre-commit
 

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -293,9 +293,17 @@ def validate(input, strict, config):
     is_flag=True,
     help="Print as JSON.",
 )
-def info(input, to_json):
+@click.option(
+    "--config",
+    "config",
+    metavar="NAME=VALUE",
+    multiple=True,
+    callback=options._cb_key_val,
+    help="GDAL configuration options.",
+)
+def info(input, to_json, config):
     """Dataset info."""
-    metadata = cog_info(input)
+    metadata = cog_info(input, config=config)
 
     if to_json:
         click.echo(metadata.json(exclude_none=True, by_alias=True))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -53,8 +53,7 @@ def test_cog_validate_valid(monkeypatch):
     assert cog_validate(raster_no_ovr, config=config)[0]
     assert not cog_validate(raster_no_ovr, strict=True, config=config)[0]
 
-    with pytest.raises(Exception):
-        cog_validate(raster_jpeg, config=config)
+    assert not cog_validate(raster_jpeg, config=config)[0]
 
     # COG created with GDAL 3.1
     assert cog_validate(raster_rioCOGgdal31, config=config)[0]


### PR DESCRIPTION
returns `False` + error message instead of raising an exception when passing a NonGeoTIFF to cog validate (and cog info)