### PR TITLE
add additional profiles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "click>=7.0",
-    "rasterio>=1.3.3",
+    "rasterio>=1.3.7",
     "numpy~=1.15",
     "morecantile>=3.1,<4.0",
     "pydantic",

--- a/rio_cogeo/profiles.py
+++ b/rio_cogeo/profiles.py
@@ -162,7 +162,35 @@ class LERCDEFLATEProfile(Profile):
     }
 
 
-class LERCDEFLATEProfile1cm(Profile):
+class LERCDEFLATEProfiledecimilli(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+        "MAX_Z_ERROR": 0.0001,
+    }
+
+
+class LERCDEFLATEProfilemilli(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+        "MAX_Z_ERROR": 0.001,
+    }
+
+
+class LERCDEFLATEProfilecenti(Profile):
     """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
 
     defaults = {
@@ -176,7 +204,7 @@ class LERCDEFLATEProfile1cm(Profile):
     }
 
 
-class LERCDEFLATEProfile10cm(Profile):
+class LERCDEFLATEProfiledeci(Profile):
     """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
 
     defaults = {
@@ -187,20 +215,6 @@ class LERCDEFLATEProfile10cm(Profile):
         "blockysize": 512,
         "compress": "LERC_DEFLATE",
         "MAX_Z_ERROR": 0.1,
-    }
-
-
-class LERCDEFLATEProfile25cm(Profile):
-    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
-
-    defaults = {
-        "driver": "GTiff",
-        "interleave": "pixel",
-        "tiled": True,
-        "blockxsize": 512,
-        "blockysize": 512,
-        "compress": "LERC_DEFLATE",
-        "MAX_Z_ERROR": 0.25,
     }
 
 
@@ -217,7 +231,35 @@ class LERCZSTDProfile(Profile):
     }
 
 
-class LERCZSTDProfile1cm(Profile):
+class LERCZSTDProfiledecimilli(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+        "MAX_Z_ERROR": 0.0001,
+    }
+
+
+class LERCZSTDProfilemilli(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+        "MAX_Z_ERROR": 0.001,
+    }
+
+
+class LERCZSTDProfilecenti(Profile):
     """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
 
     defaults = {
@@ -231,7 +273,7 @@ class LERCZSTDProfile1cm(Profile):
     }
 
 
-class LERCZSTDProfile10cm(Profile):
+class LERCZSTDProfiledeci(Profile):
     """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
 
     defaults = {
@@ -242,20 +284,6 @@ class LERCZSTDProfile10cm(Profile):
         "blockysize": 512,
         "compress": "LERC_ZSTD",
         "MAX_Z_ERROR": 0.1,
-    }
-
-
-class LERCZSTDProfile25cm(Profile):
-    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
-
-    defaults = {
-        "driver": "GTiff",
-        "interleave": "pixel",
-        "tiled": True,
-        "blockxsize": 512,
-        "blockysize": 512,
-        "compress": "LERC_ZSTD",
-        "MAX_Z_ERROR": 0.25,
     }
 
 
@@ -289,13 +317,15 @@ class COGProfiles(dict):
                 "lzma": LZMAProfile(),
                 "lerc": LERCProfile(),
                 "lerc_deflate": LERCDEFLATEProfile(),
-                "lerc_deflate_1cm": LERCDEFLATEProfile1cm(),
-                "lerc_deflate_10cm": LERCDEFLATEProfile10cm(),
-                "lerc_deflate_25cm": LERCDEFLATEProfile25cm(),
+                "lerc_deflate_decimilli": LERCDEFLATEProfiledecimilli(),
+                "lerc_deflate_milli": LERCDEFLATEProfilemilli(),
+                "lerc_deflate_centi": LERCDEFLATEProfilecenti(),
+                "lerc_deflate_deci": LERCDEFLATEProfiledeci(),
                 "lerc_zstd": LERCZSTDProfile(),
-                "lerc_zstd_1cm": LERCZSTDProfile1cm(),
-                "lerc_zstd_10cm": LERCZSTDProfile10cm(),
-                "lerc_zstd_25cm": LERCZSTDProfile25cm(),
+                "lerc_zstd_decimilli": LERCZSTDProfiledecimilli(),
+                "lerc_zstd_milli": LERCZSTDProfilemilli(),
+                "lerc_zstd_centi": LERCZSTDProfilecenti(),
+                "lerc_zstd_deci": LERCZSTDProfiledeci(),
                 "raw": RAWProfile(),
             }
         )

--- a/rio_cogeo/profiles.py
+++ b/rio_cogeo/profiles.py
@@ -62,13 +62,13 @@ class ZSTDProfilePred2(Profile):
         "blockysize": 512,
         "compress": "ZSTD",
         "PREDICTOR": 2,
-        'ZSTD_LEVEL': 1,
+        "ZSTD_LEVEL": 1,
     }
 
 
 class ZSTDProfilePred3(Profile):
     """Tiled, ZSTD-compressed GTiff. floating point differencing
-    good for floating point data, lossless 
+    good for floating point data, lossless
 
     Note: ZSTD compression is available since gdal 2.3
     """
@@ -80,7 +80,7 @@ class ZSTDProfilePred3(Profile):
         "blockysize": 512,
         "compress": "ZSTD",
         "PREDICTOR": 3,
-        'ZSTD_LEVEL': 9,
+        "ZSTD_LEVEL": 9,
     }
 
 
@@ -306,7 +306,10 @@ class COGProfiles(dict):
         if key not in (self.keys()):
             raise KeyError("{} is not a valid COG profile name".format(key))
 
-        if any(prof in key for prof in ["zstd", "webp", "lerc", "lerc_deflate", "lerc_zstd"]):
+        if any(
+            prof in key
+            for prof in ["zstd", "webp", "lerc", "lerc_deflate", "lerc_zstd"]
+        ):
             warnings.warn(
                 "Non-standard compression schema: {}. The output COG might not be fully"
                 " supported by software not build against latest libtiff.".format(key)

--- a/rio_cogeo/profiles.py
+++ b/rio_cogeo/profiles.py
@@ -48,6 +48,42 @@ class ZSTDProfile(Profile):
     }
 
 
+class ZSTDProfilePred2(Profile):
+    """Tiled, ZSTD-compressed GTiff. with horizontal differencing
+    good for byte and int16 data
+
+    Note: ZSTD compression is available since gdal 2.3
+    """
+
+    defaults = {
+        "driver": "GTiff",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "ZSTD",
+        "PREDICTOR": 2,
+        'ZSTD_LEVEL': 1,
+    }
+
+
+class ZSTDProfilePred3(Profile):
+    """Tiled, ZSTD-compressed GTiff. floating point differencing
+    good for floating point data, lossless 
+
+    Note: ZSTD compression is available since gdal 2.3
+    """
+
+    defaults = {
+        "driver": "GTiff",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "ZSTD",
+        "PREDICTOR": 3,
+        'ZSTD_LEVEL': 9,
+    }
+
+
 class LZWProfile(Profile):
     """Tiled, pixel-interleaved, LZW-compressed GTiff."""
 
@@ -126,6 +162,48 @@ class LERCDEFLATEProfile(Profile):
     }
 
 
+class LERCDEFLATEProfile1cm(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+        "MAX_Z_ERROR": 0.01,
+    }
+
+
+class LERCDEFLATEProfile10cm(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+        "MAX_Z_ERROR": 0.1,
+    }
+
+
+class LERCDEFLATEProfile25cm(Profile):
+    """Tiled, pixel-interleaved, LERC_DEFLATE-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_DEFLATE",
+        "MAX_Z_ERROR": 0.25,
+    }
+
+
 class LERCZSTDProfile(Profile):
     """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
 
@@ -136,6 +214,48 @@ class LERCZSTDProfile(Profile):
         "blockxsize": 512,
         "blockysize": 512,
         "compress": "LERC_ZSTD",
+    }
+
+
+class LERCZSTDProfile1cm(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+        "MAX_Z_ERROR": 0.01,
+    }
+
+
+class LERCZSTDProfile10cm(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+        "MAX_Z_ERROR": 0.1,
+    }
+
+
+class LERCZSTDProfile25cm(Profile):
+    """Tiled, pixel-interleaved, LERC_ZSTD-compressed GTiff."""
+
+    defaults = {
+        "driver": "GTiff",
+        "interleave": "pixel",
+        "tiled": True,
+        "blockxsize": 512,
+        "blockysize": 512,
+        "compress": "LERC_ZSTD",
+        "MAX_Z_ERROR": 0.25,
     }
 
 
@@ -161,13 +281,21 @@ class COGProfiles(dict):
                 "jpeg": JPEGProfile(),
                 "webp": WEBPProfile(),
                 "zstd": ZSTDProfile(),
+                "zstd_pred2": ZSTDProfilePred2(),
+                "zstd_pred3": ZSTDProfilePred3(),
                 "lzw": LZWProfile(),
                 "deflate": DEFLATEProfile(),
                 "packbits": PACKBITSProfile(),
                 "lzma": LZMAProfile(),
                 "lerc": LERCProfile(),
                 "lerc_deflate": LERCDEFLATEProfile(),
+                "lerc_deflate_1cm": LERCDEFLATEProfile1cm(),
+                "lerc_deflate_10cm": LERCDEFLATEProfile10cm(),
+                "lerc_deflate_25cm": LERCDEFLATEProfile25cm(),
                 "lerc_zstd": LERCZSTDProfile(),
+                "lerc_zstd_1cm": LERCZSTDProfile1cm(),
+                "lerc_zstd_10cm": LERCZSTDProfile10cm(),
+                "lerc_zstd_25cm": LERCZSTDProfile25cm(),
                 "raw": RAWProfile(),
             }
         )
@@ -178,7 +306,7 @@ class COGProfiles(dict):
         if key not in (self.keys()):
             raise KeyError("{} is not a valid COG profile name".format(key))
 
-        if key in ["zstd", "webp", "lerc", "lerc_deflate", "lerc_zstd"]:
+        if any(prof in key for prof in ["zstd", "webp", "lerc", "lerc_deflate", "lerc_zstd"]):
             warnings.warn(
                 "Non-standard compression schema: {}. The output COG might not be fully"
                 " supported by software not build against latest libtiff.".format(key)


### PR DESCRIPTION
In this PR I've made a few additional profiles that I've developed over the past year for planetary datasets (meter-resolution DEMs and grayscale 1-band byte imagery) as informed by this excellent blog post https://kokoalberti.com/articles/geotiff-compression-optimization-guide/. 

The biggest set of contributions are the additional LERC profiles that include the MAX_Z_ERROR parameters for 1cm, 10cm, and 25cm resolutions which are appropriate for meter-resolution elevation products. I picked these values as they are close to, but finer than the theoretical resolution of the more common elevation data sets encountered in planetary science, and is likely applicable to many earth-datasets save drone SfM products. 

Users attempting to encode data with precisions worse-than 50cm are probably better encoded the data as Int16. And precisions finer than 1cm starts to result in diminishing returns as well for LERC (although a 1mm lerc profile could be worth adding).

I've tested this branch locally by running a few of the new profiles against products and comparing to versions I've made by hand with gdal_translate. It appears to be working well although I haven't tested it every single new profile.

I'd accept the criticism that this adds a lot of new profiles, maybe we can think about better ways to name them or intelligently selecting predictor 2 and 3 depending on the input/output data type. 

One thing I should check on is if the floating point predictor can be applied to LERC, as that would further improve those profiles. 