### PR TITLE
Case-insensitive check for external overviews

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 3.5.1 (2023-04-06)
+
+* Use Case-insensitive check for external overviews (author @mplough-kobold, https://github.com/cogeotiff/rio-cogeo/pull/252)
+
 ## 3.5.0 (2022-10-26)
 
 * add python 3.11 support

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -445,7 +445,7 @@ def cog_validate(  # noqa: C901
 
                 return False, errors, warnings
 
-            if any(pathlib.Path(x).suffix == ".ovr" for x in src.files):
+            if any(pathlib.Path(x).suffix.lower() == ".ovr" for x in src.files):
                 errors.append(
                     "Overviews found in external .ovr file. They should be internal"
                 )


### PR DESCRIPTION
For a file `x.tiff`, GDAL will detect both `x.tiff.ovr` and `x.tiff.OVR` as external overviews.  This PR updates the overview check in rio-cogeo to match.