### PR TITLE
update morecantile and allow more TMS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,17 @@ jobs:
 
       - name: Set tag version
         id: tag
-        # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: |
+          echo "version=${GITHUB_REF#refs/*/}"
+          echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Set module version
         id: module
-        # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
-        run: echo ::set-output name=version::$(python -c 'from importlib.metadata import version; print(version("rio_cogeo"))')
+        run: |
+          echo version=$(python -c'import rio_cogeo; print(rio_cogeo.__version__)') >> $GITHUB_OUTPUT
 
       - name: Build and publish
-        if: steps.tag.outputs.tag == steps.module.outputs.version
+        if: ${{ steps.tag.outputs.version }} == ${{ steps.module.outputs.version}}
         env:
           FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
           FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## 4.0.0 (TBD)
+
+* update morecantile requirement to `>=4.0.0`
+* native support for all TileMatrixSet (with respect of the TMS spec 2.0)
+* add `--tms` option to specify a path to a TileMatrixSet JSON file
+
+**breaking change**
+
+* Web optimization is now done in rio-cogeo instead of GDAL, when using `--web-optimized` and `--use-cog-driver` options
+
+* switch from using `TILING_SCHEME` namespaced tags to simple `TILING_SCHEME_` prefixed metadata
+
+  ```python
+  # before
+  with rasterio.open("cog_web.tif") as src:
+      print(src.tags(ns="TILING_SCHEME"))
+  >>> {
+      "NAME": "WebMercatorQuad",
+      "ZOOM_LEVEL": "18",
+  }
+
+  # now
+  with rasterio.open("cog_web.tif") as src:
+      print(src.tags())
+  >>> {
+      "TILING_SCHEME_NAME": "WebMercatorQuad",
+      "TILING_SCHEME_ZOOM_LEVEL": "18",
+  }
+  ```
+
 ## 3.5.2 (2023-05-22)
 
 * Flag GeoTIFFs with invalidated optimizations as invalid COGs (author @mplough-kobold, https://github.com/cogeotiff/rio-cogeo/pull/260)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "click>=7.0",
     "rasterio>=1.3.3",
     "numpy~=1.15",
-    "morecantile>=3.1,<4.0",
+    "morecantile>=4.0,<5.0",
     "pydantic",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "D1",  # pydocstyle errors
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
+    "F",  # flake8
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
 ]

--- a/rio_cogeo/__init__.py
+++ b/rio_cogeo/__init__.py
@@ -1,6 +1,6 @@
 """rio_cogeo: Cloud Optimized GeoTIFF creation and validation plugin for rasterio."""
 
-__version__ = "3.5.2"
+__version__ = "4.0.0"
 
 from .cogeo import cog_info, cog_translate, cog_validate  # noqa
 from .profiles import cog_profiles  # noqa

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -17,7 +17,6 @@ from rasterio.env import GDALVersion
 from rasterio.io import DatasetReader, DatasetWriter, MemoryFile
 from rasterio.rio.overview import get_maximum_overview_level
 from rasterio.shutil import copy
-from rasterio.transform import array_bounds
 from rasterio.vrt import WarpedVRT
 
 from rio_cogeo import models, utils

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -17,6 +17,7 @@ from rasterio.env import GDALVersion
 from rasterio.io import DatasetReader, DatasetWriter, MemoryFile
 from rasterio.rio.overview import get_maximum_overview_level
 from rasterio.shutil import copy
+from rasterio.transform import array_bounds
 from rasterio.vrt import WarpedVRT
 
 from rio_cogeo import models, utils
@@ -195,15 +196,15 @@ def cog_translate(  # noqa: C901
             if alpha:
                 vrt_params.update({"add_alpha": False})
 
-            if web_optimized and not use_cog_driver:
-                params = utils.get_web_optimized_params(
+            if web_optimized:
+                wo_params = utils.get_web_optimized_params(
                     src_dst,
                     zoom_level_strategy=zoom_level_strategy,
                     zoom_level=zoom_level,
                     aligned_levels=aligned_levels,
                     tms=tms,
                 )
-                vrt_params.update(**params)
+                vrt_params.update(**wo_params)
 
             with WarpedVRT(src_dst, **vrt_params) as vrt_dst:
                 meta = vrt_dst.meta
@@ -310,6 +311,23 @@ def cog_translate(  # noqa: C901
                         ].name.upper()
                     }
                 )
+                if web_optimized:
+                    default_zoom = tms.zoom_for_res(
+                        max(tmp_dst.res),
+                        max_z=30,
+                        zoom_level_strategy=zoom_level_strategy,
+                    )
+                    tags.update(
+                        {
+                            "TILING_SCHEME_NAME": tms.id or "CUSTOM",
+                            "TILING_SCHEME_ZOOM_LEVEL": zoom_level
+                            if zoom_level is not None
+                            else default_zoom,
+                        }
+                    )
+                    if aligned_levels:
+                        tags["TILING_SCHEME_ALIGNED_LEVELS"] = aligned_levels
+
                 if additional_cog_metadata:
                     tags.update(**additional_cog_metadata)
 
@@ -319,26 +337,6 @@ def cog_translate(  # noqa: C901
                         if ns in ["DERIVED_SUBDATASETS", "IMAGE_STRUCTURE"]:
                             continue
                         tmp_dst.update_tags(ns=ns, **src_dst.tags(ns=ns))
-
-                if web_optimized and not use_cog_driver:
-                    default_zoom = tms.zoom_for_res(
-                        max(tmp_dst.res),
-                        max_z=30,
-                        zoom_level_strategy=zoom_level_strategy,
-                    )
-                    dst_kwargs.update(
-                        {
-                            "@TILING_SCHEME_NAME": tms.identifier,
-                            "@TILING_SCHEME_ZOOM_LEVEL": zoom_level
-                            if zoom_level is not None
-                            else default_zoom,
-                        }
-                    )
-
-                    if aligned_levels:
-                        dst_kwargs.update(
-                            {"@TILING_SCHEME_ALIGNED_LEVELS": aligned_levels}
-                        )
 
                 tmp_dst.update_tags(**tags)
                 tmp_dst._set_all_scales([vrt_dst.scales[b - 1] for b in indexes])
@@ -354,27 +352,6 @@ def cog_translate(  # noqa: C901
                         )
 
                     dst_kwargs["driver"] = "COG"
-                    if web_optimized:
-                        dst_kwargs["TILING_SCHEME"] = (
-                            "GoogleMapsCompatible"
-                            if tms.identifier == "WebMercatorQuad"
-                            else tms.identifier
-                        )
-
-                        if zoom_level is not None:
-                            if not GDALVersion.runtime().at_least("3.5"):
-                                warnings.warn(
-                                    "ZOOM_LEVEL option is only available with GDAL >3.5."
-                                )
-
-                            dst_kwargs["ZOOM_LEVEL"] = zoom_level
-
-                        dst_kwargs["ZOOM_LEVEL_STRATEGY"] = zoom_level_strategy
-
-                        if aligned_levels is not None:
-                            # GDAL uses Number of resolution (not overviews)
-                            # See https://github.com/OSGeo/gdal/issues/5336#issuecomment-1042946603
-                            dst_kwargs["aligned_levels"] = aligned_levels + 1
 
                     if add_mask and dst_kwargs.get("compress", "") != "JPEG":
                         warnings.warn(

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -1,9 +1,11 @@
 """Rio_cogeo.scripts.cli."""
 
+import json
 import os
 
 import click
 import numpy
+from morecantile import TileMatrixSet
 from rasterio.enums import Resampling as ResamplingEnums
 from rasterio.env import GDALVersion
 from rasterio.rio import options
@@ -201,6 +203,11 @@ def cogeo():
     default=False,
     show_default=True,
 )
+@click.option(
+    "--tms",
+    help="Path to TileMatrixSet JSON file.",
+    type=click.Path(),
+)
 @options.creation_options
 @click.option(
     "--config",
@@ -236,6 +243,7 @@ def create(
     forward_ns_tags,
     threads,
     use_cog_driver,
+    tms,
     creation_options,
     config,
     quiet,
@@ -261,6 +269,13 @@ def create(
         }
     )
 
+    if tms:
+        with open(tms, "r") as f:
+            tilematrixset = TileMatrixSet(**json.load(f))
+
+    else:
+        tilematrixset = None
+
     cog_translate(
         input,
         output,
@@ -281,6 +296,7 @@ def create(
         allow_intermediate_compression=allow_intermediate_compression,
         forward_band_tags=forward_band_tags,
         forward_ns_tags=forward_ns_tags,
+        tms=tilematrixset,
         use_cog_driver=use_cog_driver,
         quiet=quiet,
     )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -116,9 +116,11 @@ def test_cog_translate_web():
                 lrTile = tms.xy_bounds(tms.tile(bounds[2], bounds[1], max_zoom))
                 assert out_dst.bounds.right == lrTile.right
                 assert round(out_dst.bounds.bottom, 6) == round(lrTile.bottom, 6)
-                assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "WEBMERCATORQUAD"
-                assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"]
-                assert not out_dst.tags(ns="TILING_SCHEME").get("ALIGNED_LEVELS")
+
+                tags = out_dst.tags()
+                assert tags["TILING_SCHEME_NAME"] == "WebMercatorQuad"
+                assert tags["TILING_SCHEME_ZOOM_LEVEL"]
+                assert "TILING_SCHEME_ALIGNED_LEVELS" not in tags
 
         cog_translate(
             raster_path_web,
@@ -130,9 +132,10 @@ def test_cog_translate_web():
             aligned_levels=4,
         )
         with rasterio.open("cogeo.tif") as out_dst:
-            assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "WEBMERCATORQUAD"
-            assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"]
-            assert out_dst.tags(ns="TILING_SCHEME")["ALIGNED_LEVELS"] == "4"
+            tags = out_dst.tags()
+            assert tags["TILING_SCHEME_NAME"] == "WebMercatorQuad"
+            assert tags["TILING_SCHEME_ZOOM_LEVEL"]
+            assert tags["TILING_SCHEME_ALIGNED_LEVELS"] == "4"
 
         cog_translate(
             raster_path_web,
@@ -145,9 +148,10 @@ def test_cog_translate_web():
             aligned_levels=4,
         )
         with rasterio.open("cogeo.tif") as out_dst:
-            assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "WEBMERCATORQUAD"
-            assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"] == "19"
-            assert out_dst.tags(ns="TILING_SCHEME")["ALIGNED_LEVELS"] == "4"
+            tags = out_dst.tags()
+            assert tags["TILING_SCHEME_NAME"] == "WebMercatorQuad"
+            assert tags["TILING_SCHEME_ZOOM_LEVEL"] == "19"
+            assert tags["TILING_SCHEME_ALIGNED_LEVELS"] == "4"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
@@ -417,9 +421,10 @@ def test_gdal_zoom_options():
             use_cog_driver=True,
         )
         with rasterio.open("cogeo_gdal.tif") as out_dst:
-            assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "GOOGLEMAPSCOMPATIBLE"
-            assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"] == "18"
-            assert not out_dst.tags(ns="TILING_SCHEME").get("ALIGNED_LEVELS")
+            tags = out_dst.tags()
+            assert tags["TILING_SCHEME_NAME"] == "WebMercatorQuad"
+            assert tags["TILING_SCHEME_ZOOM_LEVEL"] == "18"
+            assert "TILING_SCHEME_ALIGNED_LEVELS" not in tags
 
 
 @requires_gdal35
@@ -443,6 +448,7 @@ def test_gdal_zoom_level_options():
             zoom_level=19,
         )
         with rasterio.open("cogeo_gdal.tif") as out_dst:
-            assert out_dst.tags(ns="TILING_SCHEME")["NAME"] == "GOOGLEMAPSCOMPATIBLE"
-            assert out_dst.tags(ns="TILING_SCHEME")["ZOOM_LEVEL"] == "19"
-            assert not out_dst.tags(ns="TILING_SCHEME").get("ALIGNED_LEVELS")
+            tags = out_dst.tags()
+            assert tags["TILING_SCHEME_NAME"] == "WebMercatorQuad"
+            assert tags["TILING_SCHEME_ZOOM_LEVEL"] == "19"
+            assert "TILING_SCHEME_ALIGNED_LEVELS" not in tags


### PR DESCRIPTION
This PR does:
- update morecantile requirements (TMS 2.0)
- add `--tms` option to specify a path to a TileMatrixSet JSON file
- support more TMS (when using GDAL COG Driver). With previous version it won't have worked 🤷 
- move all `web optimization` in rio-cogeo when using the COG driver
- use simple metadata tags with  `TILING_SCHEME` prefix instead of `TILING_SCHEME` namespace (because it's not possible with GDAL COG driver atm)