### PR TITLE
Add Progress Option

### DIFF
--- a/docs/docs/API.md
+++ b/docs/docs/API.md
@@ -108,22 +108,28 @@ with MemoryFile() as mem_dst:
     client.upload_fileobj(mem_dst, "my-bucket", "my-key")
 ```
 
-3. Progress to TextIO
+3. Output Progress to Alternative Text Buffer
 
+Use Case: You may want to run your translation tasks in the background and keep
+track of progress. To do so you can utilize an alternative text buffer and another
+thread. By outputting the progress to a seperate text buffer you can then track
+the translation progress without blocking the program.
 ```python
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
 
-config = dict(
-    GDAL_NUM_THREADS="ALL_CPUS",
-    GDAL_TIFF_INTERNAL_MASK=True,
-    GDAL_TIFF_OVR_BLOCKSIZE="128",
-)
+config = {
+    "GDAL_NUM_THREADS": "ALL_CPUS",
+    "GDAL_TIFF_INTERNAL_MASK": True,
+    "GDAL_TIFF_OVR_BLOCKSIZE": "128",
+}
 
 
+with open("logfile.txt", "w+") as buffer:
 
-with open("logfile.txt", "w+") as example:
-    example.isatty = lambda: True # Enable Interactive File like terminal
+    # Progress output buffer must be interactive
+    buffer.isatty = lambda: True
+
     cog_translate(
         "example-input.tif",
         "example-output.tif",
@@ -131,6 +137,18 @@ with open("logfile.txt", "w+") as example:
         config=config,
         in_memory=False,
         nodata=0,
-        quiet=example,
+        quiet=False,
+        progress_out=buffer,
     )
 ```
+
+Below is a snippet of code that allows you to grab the percentage complete a
+translation is using the text buffer.
+
+```python
+import re
+
+def getPercentage(buffer:str) -> float:
+    return int(re.findall("\d*%", buffer)[-1].replace("%", "")) / 100
+```
+

--- a/docs/docs/API.md
+++ b/docs/docs/API.md
@@ -107,3 +107,28 @@ with MemoryFile() as mem_dst:
     client = boto3_session.client("s3")
     client.upload_fileobj(mem_dst, "my-bucket", "my-key")
 ```
+
+3. Progress to TextIO
+
+```python
+from rio_cogeo.cogeo import cog_translate
+from rio_cogeo.profiles import cog_profiles
+
+config = dict(
+    GDAL_NUM_THREADS="ALL_CPUS",
+    GDAL_TIFF_INTERNAL_MASK=True,
+    GDAL_TIFF_OVR_BLOCKSIZE="128",
+)
+
+with open("logfile.txt", "w+") as example:
+    cog_translate(
+        "example-input.tif",
+        "example-output.tif",
+        cog_profiles.get("deflate"),
+        config=config,
+        in_memory=False,
+        nodata=0,
+        quiet=False,
+        progress=example
+    )
+```

--- a/docs/docs/API.md
+++ b/docs/docs/API.md
@@ -120,7 +120,10 @@ config = dict(
     GDAL_TIFF_OVR_BLOCKSIZE="128",
 )
 
+
+
 with open("logfile.txt", "w+") as example:
+    example.isatty = lambda: True # Enable Interactive File like terminal
     cog_translate(
         "example-input.tif",
         "example-output.tif",
@@ -128,7 +131,6 @@ with open("logfile.txt", "w+") as example:
         config=config,
         in_memory=False,
         nodata=0,
-        quiet=False,
-        progress=example
+        quiet=example,
     )
 ```

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -92,7 +92,8 @@ def cog_translate(  # noqa: C901
     allow_intermediate_compression: bool = False,
     forward_band_tags: bool = False,
     forward_ns_tags: bool = False,
-    quiet: Union[bool, TextIO] = False,
+    quiet: bool = False,
+    progress_out: Optional[TextIO] = None,
     temporary_compression: str = "DEFLATE",
     colormap: Optional[Dict] = None,
     additional_cog_metadata: Optional[Dict] = None,
@@ -153,8 +154,10 @@ def cog_translate(  # noqa: C901
         Ref: https://github.com/cogeotiff/rio-cogeo/issues/19
     forward_ns_tags:  bool, optional
         Forward namespaces tags to output dataset.
-    quiet: bool, TextIO, optional (default: False)
-        Mask processing steps. Define the output buffer for the progress bar.
+    quiet: bool, optional (default: False)
+        Mask processing steps.
+    progress_out: TextIO, optional
+        Output progress steps to alternative text buffer. Quiet must be False.
     temporary_compression: str, optional
         Compression used for the intermediate file, default is deflate.
     colormap: dict, optional
@@ -301,11 +304,9 @@ def cog_translate(  # noqa: C901
                 if not quiet:
                     click.echo("Reading input: {}".format(source), err=True)
 
-                fout = sys.stderr
-                if quiet is True:
-                    fout = ctx.enter_context(open(os.devnull, "w"))
-                elif quiet is not False:
-                    fout = quiet
+                fout = ctx.enter_context(open(os.devnull, "w")) if quiet else sys.stderr
+                if quiet is False and progress_out:
+                    fout = progress_out
 
                 with click.progressbar(wind, file=fout, show_percent=True) as windows:  # type: ignore
                     for _, w in windows:

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -6,9 +6,8 @@ import sys
 import tempfile
 import warnings
 from contextlib import ExitStack, contextmanager
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, TextIO, Tuple, Union
 
-import _io
 import click
 import morecantile
 import rasterio
@@ -93,8 +92,7 @@ def cog_translate(  # noqa: C901
     allow_intermediate_compression: bool = False,
     forward_band_tags: bool = False,
     forward_ns_tags: bool = False,
-    quiet: bool = False,
-    progress: Union[bool, _io.TextIOWrapper] = False,
+    quiet: Union[bool, TextIO] = False,
     temporary_compression: str = "DEFLATE",
     colormap: Optional[Dict] = None,
     additional_cog_metadata: Optional[Dict] = None,
@@ -155,10 +153,8 @@ def cog_translate(  # noqa: C901
         Ref: https://github.com/cogeotiff/rio-cogeo/issues/19
     forward_ns_tags:  bool, optional
         Forward namespaces tags to output dataset.
-    quiet: bool, optional (default: False)
-        Mask processing steps.
-    progress: _io.TextIOWrapper, False, options (default: False)
-        Output progress precentage to TextIO. Quiet must be False.
+    quiet: bool, TextIO, optional (default: False)
+        Mask processing steps. Define the output buffer for the progress bar.
     temporary_compression: str, optional
         Compression used for the intermediate file, default is deflate.
     colormap: dict, optional
@@ -305,26 +301,21 @@ def cog_translate(  # noqa: C901
                 if not quiet:
                     click.echo("Reading input: {}".format(source), err=True)
 
-                fout = ctx.enter_context(open(os.devnull, "w")) if quiet else sys.stderr
-
-                def updateProgress(pct):
-                    if type(progress) == _io.TextIOWrapper and not quiet:
-                        progress.write(str(windows.pct) + "\n")
-                        progress.flush()
+                fout = sys.stderr
+                if quiet is True:
+                    fout = ctx.enter_context(open(os.devnull, "w"))
+                elif quiet is not False:
+                    fout = quiet
 
                 with click.progressbar(wind, file=fout, show_percent=True) as windows:  # type: ignore
                     for _, w in windows:
                         matrix = vrt_dst.read(window=w, indexes=indexes)
-                        updateProgress(windows.pct)
                         tmp_dst.write(matrix, window=w)
-                        updateProgress(windows.pct)
 
                         if add_mask or mask:
                             # Cast mask to uint8 to fix rasterio 1.1.2 error (ref #115)
                             mask_value = vrt_dst.dataset_mask(window=w).astype("uint8")
-                            updateProgress(windows.pct)
                             tmp_dst.write_mask(mask_value, window=w)
-                            updateProgress(windows.pct)
 
                 if overview_level is None:
                     overview_level = get_maximum_overview_level(


### PR DESCRIPTION
I am working on a project that utilized rio-cogeo and we needed to be able to get the progress of a conversion. I thought other people might also have this issue. Basically, what this new feature allows you to do is set a TextIO output (like sys.stdout) to output the progress as a percentage to (and just the percentage). This would allow something else to read this TextIO to get the percentage that the conversion is at. This can be extremely useful to allow developers to check the progress of an update.

Let me know if you have any questions.