### PR TITLE
Replace usage of is_tiled with tests of block shapes

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -465,7 +465,7 @@ def cog_validate(  # noqa: C901
 
             overviews = src.overviews(1)
             if src.width > 512 and src.height > 512:
-                if not src.is_tiled:
+                if src.block_shapes[0][1] == src.width and src.block_shapes[0][1] > 1024:
                     errors.append(
                         "The file is greater than 512xH or 512xW, but is not tiled"
                     )
@@ -592,7 +592,7 @@ def cog_validate(  # noqa: C901
         for ix, _dec in enumerate(overviews):
             with rasterio.open(src_path, OVERVIEW_LEVEL=ix) as ovr_dst:
                 if ovr_dst.width > 512 and ovr_dst.height > 512:
-                    if not ovr_dst.is_tiled:
+                    if ovr_dst.block_shapes[0][1] == ovr_dst.width:
                         errors.append("Overview of index {} is not tiled".format(ix))
 
     if warnings and not quiet:
@@ -660,7 +660,7 @@ def cog_info(
                 Bands=src_dst.count,
                 Width=src_dst.width,
                 Height=src_dst.height,
-                Tiled=src_dst.is_tiled,
+                Tiled=(src_dst.block_shapes[0][1] != src.width),
                 Dtype=src_dst.dtypes[0],
                 Interleave=src_dst.interleaving.value
                 if src_dst.interleaving

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -465,7 +465,7 @@ def cog_validate(  # noqa: C901
 
             overviews = src.overviews(1)
             if src.width > 512 and src.height > 512:
-                if src.block_shapes[0][1] == src.width and src.block_shapes[0][1] > 1024:
+                if src.block_shapes and src.block_shapes[0][1] == src.width:
                     errors.append(
                         "The file is greater than 512xH or 512xW, but is not tiled"
                     )
@@ -592,7 +592,10 @@ def cog_validate(  # noqa: C901
         for ix, _dec in enumerate(overviews):
             with rasterio.open(src_path, OVERVIEW_LEVEL=ix) as ovr_dst:
                 if ovr_dst.width > 512 and ovr_dst.height > 512:
-                    if ovr_dst.block_shapes[0][1] == ovr_dst.width:
+                    if (
+                        ovr_dst.block_shapes
+                        and ovr_dst.block_shapes[0][1] == ovr_dst.width
+                    ):
                         errors.append("Overview of index {} is not tiled".format(ix))
 
     if warnings and not quiet:

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -660,7 +660,7 @@ def cog_info(
                 Bands=src_dst.count,
                 Width=src_dst.width,
                 Height=src_dst.height,
-                Tiled=(src_dst.block_shapes[0][1] != src.width),
+                Tiled=(src_dst.block_shapes[0][1] != src_dst.width),
                 Dtype=src_dst.dtypes[0],
                 Interleave=src_dst.interleaving.value
                 if src_dst.interleaving

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_cogeo_valid(runner):
             assert src.height == 512
             assert src.width == 512
             assert src.meta["dtype"] == "uint8"
-            assert src.is_tiled
+            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
             assert src.compression.value == "DEFLATE"
             assert not src.photometric
             assert src.interleaving.value == "PIXEL"
@@ -205,7 +205,7 @@ def test_cogeo_validOvrOption(runner):
         assert not result.exception
         assert result.exit_code == 0
         with rasterio.open("output.tif") as src:
-            assert src.is_tiled
+            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
             assert src.overviews(1) == [2, 4]
 
 
@@ -228,7 +228,7 @@ def test_cogeo_overviewTilesize(monkeypatch, runner):
         assert not result.exception
         assert result.exit_code == 0
         with rasterio.open("output.tif") as src:
-            assert src.is_tiled
+            assert all([(128, 128) == (h, w) for (h, w) in src.block_shapes])
             assert src.overviews(1)
 
         with rasterio.open("output.tif", OVERVIEW_LEVEL=1) as src:
@@ -242,7 +242,7 @@ def test_cogeo_overviewTilesize(monkeypatch, runner):
         assert not result.exception
         assert result.exit_code == 0
         with rasterio.open("output.tif") as src:
-            assert src.is_tiled
+            assert all([(128, 128) == (h, w) for (h, w) in src.block_shapes])
             assert src.overviews(1)
 
         with rasterio.open("output.tif", OVERVIEW_LEVEL=1) as src:
@@ -332,7 +332,7 @@ def test_cogeo_validgdalBlockOption(runner):
         assert not result.exception
         assert result.exit_code == 0
         with rasterio.open("output.tif") as src:
-            assert src.is_tiled
+            assert all([(128, 128) == (h, w) for (h, w) in src.block_shapes])
             assert src.overviews(1) == [2, 4]
 
 

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -60,7 +60,7 @@ def _validate_translated_rgb_jpeg(src):
     assert src.height == 512
     assert src.width == 512
     assert src.meta["dtype"] == "uint8"
-    assert src.is_tiled
+    assert all([(64, 64) == (h, w) for (h, w) in src.block_shapes])
     assert src.profile["blockxsize"] == 64
     assert src.profile["blockysize"] == 64
     assert src.compression.value == "JPEG"
@@ -127,7 +127,7 @@ def test_cog_translate_validRaw(runner):
         with rasterio.open("cogeo.tif") as src:
             assert src.height == 512
             assert src.width == 512
-            assert src.is_tiled
+            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
             assert not src.compression
             assert src.interleaving.value == "PIXEL"
 
@@ -161,7 +161,7 @@ def test_cog_translate_validAlpha(runner):
             assert src.height == 512
             assert src.width == 512
             assert src.meta["dtype"] == "uint8"
-            assert src.is_tiled
+            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
             assert src.compression.value == "WEBP"
             assert has_alpha_band(src)
 
@@ -259,7 +259,7 @@ def test_cog_translate_validCustom(runner):
             assert src.height == 512
             assert src.width == 512
             assert src.meta["dtype"] == "uint8"
-            assert src.is_tiled
+            assert all([(256, 256) == (h, w) for (h, w) in src.block_shapes])
             assert src.compression.value == "JPEG"
             assert src.profile["blockxsize"] == 256
             assert src.profile["blockysize"] == 256
@@ -317,7 +317,7 @@ def test_cog_translate_valid_blocksize(runner):
         with rasterio.open("cogeo.tif") as src:
             assert src.height == 171
             assert src.width == 171
-            assert src.is_tiled
+            all([(128, 128) == (h, w) for (h, w) in src.block_shapes])
             assert src.profile["blockxsize"] == 128
             assert src.profile["blockysize"] == 128
             assert src.overviews(1) == [2]
@@ -327,7 +327,7 @@ def test_cog_translate_valid_blocksize(runner):
         with rasterio.open("cogeo.tif") as src:
             assert src.height == 51
             assert src.width == 51
-            assert src.is_tiled
+            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
             assert src.profile.get("blockxsize") == 512
             assert src.profile.get("blockysize") == 512
             assert not src.overviews(1)

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -127,7 +127,7 @@ def test_cog_translate_validRaw(runner):
         with rasterio.open("cogeo.tif") as src:
             assert src.height == 512
             assert src.width == 512
-            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
+            assert all([(64, 64) == (h, w) for (h, w) in src.block_shapes])
             assert not src.compression
             assert src.interleaving.value == "PIXEL"
 
@@ -161,7 +161,7 @@ def test_cog_translate_validAlpha(runner):
             assert src.height == 512
             assert src.width == 512
             assert src.meta["dtype"] == "uint8"
-            assert all([(512, 512) == (h, w) for (h, w) in src.block_shapes])
+            assert all([(64, 64) == (h, w) for (h, w) in src.block_shapes])
             assert src.compression.value == "WEBP"
             assert has_alpha_band(src)
 


### PR DESCRIPTION
This future proofs rio-cogeo and makes it more strictly conforming to what the official GDAL COG checker does.

Background: https://github.com/rasterio/rasterio/discussions/3014. 