### PR TITLE
Fix for issue #281 COG validation fails for sparse edge tiles

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -564,7 +564,26 @@ def cog_validate(  # noqa: C901
                             )
                         )
 
-            block_offset = src.get_tag_item("BLOCK_OFFSET_0_0", "TIFF", bidx=1)
+            # Get blocks size
+            block_size = src.block_shapes[0]
+
+            # Extract number of blocks per row and column
+            blocks_per_row = src.width // block_size[1]
+            blocks_per_column = src.height // block_size[0]
+
+            # Initialize loop variables
+            y = 0
+            block_offset = None
+
+            # Find the first block with a valid block_offset
+            while y < blocks_per_column and block_offset is None:
+                x = 0
+                while x < blocks_per_row and block_offset is None:
+                    block_offset = src.get_tag_item(
+                        "BLOCK_OFFSET_%d_%d" % (x, y), "TIFF", bidx=1
+                    )
+                    x += 1
+                y += 1
 
             data_offset = int(block_offset) if block_offset else 0
             data_offsets = [data_offset]
@@ -572,9 +591,29 @@ def cog_validate(  # noqa: C901
             details["data_offsets"]["main"] = data_offset
 
             for ix, _dec in enumerate(overviews):
-                block_offset = src.get_tag_item(
-                    "BLOCK_OFFSET_0_0", "TIFF", bidx=1, ovr=ix
-                )
+
+                # Get the width and height of the overview
+                overview_width = src.width // (_dec)
+                overview_height = src.height // (_dec)
+
+                # Extract number of blocks per row and column
+                blocks_per_row = overview_width // block_size[1]
+                blocks_per_column = overview_height // block_size[0]
+
+                # Initialize loop variables
+                y = 0
+                block_offset = None
+
+                # Find the first block with a valid block_offset
+                while y < blocks_per_column and block_offset is None:
+                    x = 0
+                    while x < blocks_per_row and block_offset is None:
+                        block_offset = src.get_tag_item(
+                            "BLOCK_OFFSET_%d_%d" % (x, y), "TIFF", bidx=1, ovr=ix
+                        )
+                        x += 1
+                    y += 1
+
                 data_offset = int(block_offset) if block_offset else 0
                 data_offsets.append(data_offset)
                 details["data_offsets"]["overview_{}".format(ix)] = data_offset

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -19,6 +19,7 @@ raster_decim = os.path.join(fixture_dir, "validate", "image_dec.tif")
 raster_jpeg = os.path.join(fixture_dir, "validate", "nontiff.jpg")
 raster_big = os.path.join(fixture_dir, "image_2000px.tif")
 raster_zero_offset = os.path.join(fixture_dir, "validate", "cog_no_offest.tif")
+raster_sparse = os.path.join(fixture_dir, "validate", "sparse.tif")
 
 # COG created with rio-cogeo but using gdal 3.1
 raster_rioCOGgdal31 = os.path.join(fixture_dir, "validate", "image_rioCOG_gdal3.1.tif")
@@ -70,6 +71,9 @@ def test_cog_validate_valid(monkeypatch):
 
     with pytest.warns(NotGeoreferencedWarning):
         assert cog_validate(raster_zero_offset, config=config)
+
+    # Sparse COG with some overviews that contain zeros
+    assert cog_validate(raster_sparse, config=config)[0]
 
 
 def test_cog_validate_return():


### PR DESCRIPTION
#281 
The rio-cogeo validator returns False even though it is a valid COG when there are sparse edge tiles in the file and/or overviews.

This was because the overviews are stored as sparse and the validator checks for the first tile offset of each overview (BLOCK_OFFSET_0_0 tag). Since there are sparse edge tiles, this value is zero, and it cannot verify that the overviews are in the right order, even though they are.

I changed the code to iterate over BLOCK_OFFSET_x_y based on the number of tile rows/columns for the main file and overviews. This makes sure that the data_offset variable gets populated if there is an offset after all the sparse tiles.

Added a new test that checks for a sparse image with sparse tiles on the edges. I also added the tif image for the test.