### PR TITLE
Fix reading raster compression value with rasterio 1.4.3

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -738,7 +738,7 @@ def cog_info(
     with rasterio.Env(**config):
         with rasterio.open(src_path) as src_dst:
             driver = src_dst.driver
-            compression = src_dst.compression.value if src_dst.compression else None
+            compression = getattr(src_dst.compression, "value", src_dst.compression)
             colorspace = src_dst.photometric.value if src_dst.photometric else None
             overviews = src_dst.overviews(1)
 

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -65,7 +65,7 @@ def _validate_translated_rgb_jpeg(src):
     assert all([(64, 64) == (h, w) for (h, w) in src.block_shapes])
     assert src.profile["blockxsize"] == 64
     assert src.profile["blockysize"] == 64
-    assert src.compression.value == "JPEG"
+    assert src.compression == "YCbCr JPEG" or src.compression.value == "JPEG"
     assert src.photometric.value == "YCbCr"
     assert src.interleaving.value == "PIXEL"
     assert src.overviews(1) == [2, 4, 8]
@@ -101,7 +101,9 @@ def test_cog_translate_NodataLossyWarning(runner):
             )
             with rasterio.open("cogeo.tif") as src:
                 assert not src.nodata
-                assert src.compression.value == "JPEG"
+                assert (
+                    src.compression == "YCbCr JPEG" or src.compression.value == "JPEG"
+                )
                 assert has_mask_band(src)
 
 
@@ -186,7 +188,9 @@ def test_cog_translate_validAlpha(runner):
             )
             with rasterio.open("cogeo.tif") as src:
                 assert src.count == 3
-                assert src.compression.value == "JPEG"
+                assert (
+                    src.compression == "YCbCr JPEG" or src.compression.value == "JPEG"
+                )
                 assert has_mask_band(src)
 
         with pytest.warns(UserWarning):
@@ -291,7 +295,7 @@ def test_cog_translate_validCustom(runner):
             assert src.width == 512
             assert src.meta["dtype"] == "uint8"
             assert all([(256, 256) == (h, w) for (h, w) in src.block_shapes])
-            assert src.compression.value == "JPEG"
+            assert src.compression == "YCbCr JPEG" or src.compression.value == "JPEG"
             assert src.profile["blockxsize"] == 256
             assert src.profile["blockysize"] == 256
             assert src.photometric.value == "YCbCr"


### PR DESCRIPTION
Closes https://github.com/cogeotiff/rio-cogeo/issues/299

I’ve made `cog_info()` and the tests compatible with `rasterio 1.4.3` and with `rasterio <= 1.4.2`, but I suppose that only the configuration with `rasterio 1.4.3` will be tested in CI?